### PR TITLE
remove topics page. fixes issue #10

### DIFF
--- a/topics.md
+++ b/topics.md
@@ -1,2 +1,0 @@
-- topics - description
-  - gotta lear how these work before i can come up with an outline :^)


### PR DESCRIPTION
As the subject line says.
- topics will be covered in the channel guide. no need for their own page.
