### PR TITLE
correct and explicitly specify language

### DIFF
--- a/B_adding_pages.md
+++ b/B_adding_pages.md
@@ -5,7 +5,7 @@ Our task for this guide is to add two new pages to our Phoenix application. One 
 
 When Phoenix generates a new application for us, it builds a top level directory structure like this.
 
-```
+```text
 ├── _build
 ├── config
 ├── deps
@@ -18,7 +18,7 @@ When Phoenix generates a new application for us, it builds a top level directory
 
 Most of our work in this tutorial will be in the web directory, which looks like this when expanded.
 
-```
+```text
 ├── channels
 ├── controllers
 │   └── page_controller.ex
@@ -40,7 +40,7 @@ All of the files which are currently in the controllers, templates and views dir
 
 All of our application's static assets live in priv/static in the directory appropriate for each type of file - css, images or js. We won't be making any changes here for now, but it's good to know where to look for future reference.
 
-```
+```text
 priv
 └── static
     ├── css
@@ -57,7 +57,7 @@ Enough prep, let's get on with our first new Phoenix page!
 
 Routes map unique http verb/path pairs to controller/action pairs which will handle them. The route for our "Welcome to Phoenix!" page from the previous guide looks like this.
 
-```
+```elixir
 get "/", HelloPhoenix.PageController, :index, as: :pages
 ```
 
@@ -137,7 +137,7 @@ Templates are scoped to a controller. In practice, this simply means that we cre
 
 Let's do that now. Create web/templates/hello/index.html.eex and make it look like this.
 
-```elixir
+```html
 <div class="jumbotron">
   <h2>Hello from Phoenix!</h2>
 </div>
@@ -197,7 +197,7 @@ To do that, we'll use the special eex tags for executing Elixir expressions - <%
 
 And this is what the template should look like.
 
-```elixir
+```html
 <div class="jumbotron">
   <h2>Hello World, from <%= @messenger %>!</h2>
 </div>

--- a/C_routing.md
+++ b/C_routing.md
@@ -42,13 +42,13 @@ If you do create an ambiguous route, the router will still compile, but you will
 
 Define this route at the very bottom of your router.
 
-```
+```elixir
 get "/", HelloPhoenix.RootController, :index
 ```
 
 Then run `$ mix compile` at the root of your project. You will see the following warning from the compiler.
 
-```
+```text
 web/router.ex:1: warning: this clause cannot match because a previous clause at line 1 always matches
 Compiled web/router.ex
 ```
@@ -59,7 +59,7 @@ Phoenix provides a great tool for investigating routes in your application, the 
 
 Let's see how this works. Go to the root of a newly-generated Phoenix application and run `$ mix phoenix.routes`. (If you haven't already done so, you'll need to run `$ mix do deps.get, compile` before running the routes task.) You should see something like this.
 
-```
+```console
 $ mix phoenix.routes
 pages_path  GET  /  HelloPhoenix.PageController.index/2
 ```
@@ -80,7 +80,7 @@ By adding "as: :pages", we have in effect named a resource for this route; we've
 
 That's a mouthful. Let's see it in action. Run `$ iex -S mix` at the root of the project. When we call the pages_path function on our router with the action as an argument, it returns the path to us.
 
-```
+```elixir
 iex(4)> HelloPhoenix.Router.Helpers.pages_path(:index)
 "/"
 ```
@@ -94,7 +94,7 @@ If you try to give the same name to another route, the router will not compile. 
 
 Then run `$ mix compile`
 
-```
+```text
 == Compilation error on file web/router.ex ==
 ** (CompileError) web/router.ex:1: def pages_path/1 has default values and multiple clauses, define a function head with the defaults
     (elixir) src/elixir_def.erl:340: :elixir_def.store_each/8
@@ -175,7 +175,7 @@ Running `$ mix phoenix.routes` now shows that we have all the routes except the 
 ###Path Helpers
 The phoenix.routes task also listed the user_path as the path function for each line of output. Here is what that path translates to for each action.
 
-```
+```elixir
 iex(2)> HelloPhoenix.Router.Helpers.user_path(:index)
 "/users"
 
@@ -260,7 +260,7 @@ Scopes are a way to group routes under a common path prefix. We might want to do
 
 The paths to the user facing reviews would look like a standard resource.
 
-```elixir
+```text
 /reviews
 /reviews/1234
 /reviews/1234/edit
@@ -270,7 +270,7 @@ and so on
 
 The admin review paths could be prefixed with "/admin".
 
-```elixir
+```text
 /admin/reviews
 /admin/reviews/1234
 /admin/reviews/1234/edit
@@ -288,7 +288,7 @@ end
 
 Note that the path we set must begin with a slash. Without the slash, when we run `$ mix phoenix.routes`, the compiler will give this handy error message.
 
-```elixir
+```text
 == Compilation error on file web/router.ex ==
 ** (ArgumentError) Path must start with slash.
 Change path from:

--- a/D_controllers.md
+++ b/D_controllers.md
@@ -109,7 +109,7 @@ In order to see our flash messages, we need to be able to pull them off of the `
 
 Let's put these blocks in our application layout. They are designed to work if we have one or many messages set on each key.
 
-```elixir
+```html
 <%= for error <- Flash.get_all(@conn, :error) do %>
       <div class="flash_error">
         <div class="row">
@@ -125,7 +125,7 @@ Let's put these blocks in our application layout. They are designed to work if w
          </div>
        </div>
   <% end %>
- ```
+```
 
  When we reload the page, our messages should appear.
 
@@ -229,14 +229,14 @@ def index(conn, params) do
   |> put_layout(:none)
   |> render "index"
 end
- ```
+```
 When you start the application and view `http://localhost:4000/`, you should see a very different page, one with no title, logo image, or css styling at all.
 
 Very Important! For function calls in the middle of a pipeline, like `put_layout/2` here, it is critical to use parenthesis around the arguments because the pipeline operator binds more tightly. This leads to parsing problems and very strange results.
 
 If you ever get a stack trace that looks like this,
 
-```
+```text
 **(FunctionClauseError) no function clause matching in Plug.Conn.get_resp_header/2
 
 Stacktrace
@@ -254,7 +254,7 @@ def index(conn, params) do
   |> put_layout(:none)
   |> render "index"
 end
- ```
+```
 
 This won't work.
 
@@ -264,11 +264,11 @@ def index(conn, params) do
   |> put_layout :none
   |> render "index"
 end
- ```
+```
 
 Now let's actually create another layout and render the index template into it. As an example, let's say we had a different layout for the admin section of our application which didn't have the logo image. To do this, let's copy the existing `application.html.eex` to a new file `admin.html.eex`. Then remove the line in it that displays the logo.
 
-```elixir
+```html
 <span class="logo"></span> <!-- remove this line -->
 ```
 
@@ -280,7 +280,7 @@ def index(conn, params) do
   |> put_layout("admin")
   |> render "index"
 end
- ```
+```
 
 Reload the page, and we should be rendering the admin layout with no logo.
 

--- a/E_views.md
+++ b/E_views.md
@@ -44,7 +44,7 @@ What might a real world example look like? Let's say we have users in our system
 
 The application, however, may need to present the user's full name. We could do this by concatenating the values of those fields into a single string in each template that needs it. It's much cleaner, however, to do something like this.
 
-```elixir
+```html
 <p>Full Name <%= full_name(user) %></p>
 ```
 Let's say that there are a number of templates which will need the user's full name, and that a different view renders each of them. The way to handle that is to define a `full_name/1` function in the appication view.

--- a/H_ecto-models.md
+++ b/H_ecto-models.md
@@ -28,8 +28,8 @@ end
 
 And then install the dependenciew with:
 
-```
-mix deps.get
+```console
+$ mix deps.get
 ```
 
 ### Add a Repository

--- a/K_deployment.md
+++ b/K_deployment.md
@@ -10,7 +10,7 @@ Deployment is great and all, but be sure you have these things before continuing
 - Build environment
 - Hosting environment
 
-> Psst! Your hosting environment and your build environment can be one in the same if you're doing a test run. 
+> Psst! Your hosting environment and your build environment can be one in the same if you're doing a test run.
 
 Be sure that the architectures for both your build and hosting environments are the same, e.g. 64-bit Linux -> 64-bit Linux. Without doing this, you run the risk of your application not running. Using a virtual machine for your build environment that mirrors your hosting environment will be an easy way to ensure you don't have any such problems when deploying your application.
 
@@ -41,7 +41,7 @@ To get started, we'll need to add exrm into our list of dependencies. With later
 
 With that taken care of, a simple `mix do deps.get, deps.compile` will pull down exrm and its dependencies, along with the rest of your application's dependencies, and ensures that everything compiles so exrm's mix tasks are available as well. Speaking of...
 
-```
+```console
 $ mix help
 mix                   # Run the default task (current: mix run)
 ...
@@ -50,7 +50,7 @@ mix release.clean     # Clean up any release-related files.
 mix release.plugins   # View information about active release plugins
 mix run               # Run the given file or expression
 mix test              # Run a project's tests
-iex -S mix            # Start IEx and run the default task 
+iex -S mix            # Start IEx and run the default task
 ```
 
 Bam! Now we're cooking with fire!
@@ -90,7 +90,7 @@ Add our application's router as a child to our application's supervisor:
 
 Once this worker exists in your supervisor, `mix phoenix.start` will no longer work like before as you'll end up seeing an error message similar to:
 
-```
+```text
 ** (CaseClauseError) no case clause matching: {:error, {:already_started, #PID<0.168.0>}}
     (phoenix) lib/phoenix/router.ex:75: Phoenix.Router.start_adapter/2
     (phoenix) lib/mix/tasks/phoenix/start.ex:12: Mix.Tasks.Phoenix.Start.run/1
@@ -107,7 +107,7 @@ Running `mix release` will kick off the build process for our release.
 
 > Note: In the following sections, you'll see our application's version (`0.0.1`) pop up in bunch of places. This value is pulled from the application's `mix.exs` file, under the project's version.
 
-```
+```console
 $ mix release
 ==> Generating relx configuration...
 ==> Generating sys.config...
@@ -130,7 +130,7 @@ Once we see `==> The release for my_app-0.0.1 is ready!` pop up in our console, 
 
 #### Contents of a release
 
-```
+```console
 $ ls -la rel/my_app
 total 21488
 drwxr-xr-x   7 shane  staff       238 Aug 22 10:03 .
@@ -144,11 +144,11 @@ drwxr-xr-x   5 shane  staff       170 Aug 22 10:03 releases
 
 `bin` contains our generated executables for running our application.  The `bin/my_app` executable is what we will eventually use to issue commands to our application.
 
-`erts-6.1` contains all necessary files for the Erlang run-time system, pulled from our build environment. 
+`erts-6.1` contains all necessary files for the Erlang run-time system, pulled from our build environment.
 
-`lib` contains the compiled BEAM files for our applicaiton and all of our dependencies. This is where all of your hard work goes. 
+`lib` contains the compiled BEAM files for our applicaiton and all of our dependencies. This is where all of your hard work goes.
 
-`releases` is the home for our releases, being used to house any release-dependent configurations and scripts that exrm finds necessary for running our application. 
+`releases` is the home for our releases, being used to house any release-dependent configurations and scripts that exrm finds necessary for running our application.
 
 The tarball is our release in archive form, ready to be shipped off to our hosting environment.
 
@@ -156,7 +156,7 @@ The tarball is our release in archive form, ready to be shipped off to our hosti
 
 Before deploying our release, we should make sure that it runs on our build environment. To do that, we will issue the `console` command to our executable, essentially running our application via `iex`.
 
-```
+```console
 $ rel/my_app/bin/my_app console
 Exec: /Users/shane/code/elixir/my_app/rel/my_app/erts-6.1/bin/erlexec -boot /Users/shane/code/elixir/my_app/rel/my_app/releases/0.0.1/my_app -env ERL_LIBS /Users/shane/code/elixir/my_app/rel/my_app/lib -config /Users/shane/code/elixir/my_app/rel/my_app/releases/0.0.1/sys.config -pa /Users/shane/code/elixir/my_app/rel/my_app/lib/consolidated -args_file /Users/shane/code/elixir/my_app/rel/my_app/releases/0.0.1/vm.args -user Elixir.IEx.CLI -extra --no-halt +iex -- console
 Root: /Users/shane/code/elixir/my_app/rel/my_app
@@ -165,7 +165,7 @@ Erlang/OTP 17 [erts-6.1] [source-d2a4c20] [64-bit] [smp:4:4] [async-threads:10] 
 
 Interactive Elixir (0.15.2-dev) - press Ctrl+C to exit (type h() ENTER for help)
 iex(my_app@127.0.0.1)1>
-``` 
+```
 
 This is the point where your application will crash if it fails to start a child application. However, if all goes well, you should be dropped into an `iex` prompt. Congratulations! We're ready to deploy our application!
 
@@ -175,14 +175,14 @@ Now comes the easy part! There are many ways for us to get our tarballed release
 
 In our example, we'll use SCP to upload to a remote server.
 
-```
+```console
 $ scp -i ~/.ssh/id_rsa.pub rel/my_app/my_app-0.0.1.tar.gz ubuntu@hostname.com:/home/ubuntu
 my_app-0.0.1.tar.gz                100%   18MB  80.0KB/s   03:48
 ```
 
 Hooray! Let's SSH into that environment to set our application up.
 
-```
+```console
 $ ssh -i ~/.ssh/id_rsa.pub ubuntu@hostname.com
 $ sudo mkdir -p /app
 $ sudo chown ubuntu:ubuntu /app
@@ -202,7 +202,7 @@ First step in exposing our application to the world is ensuring that our applica
 
 In this case, we'll be using `upstart` as our OS is Ubuntu, and `upstart` has been bundled with Ubuntu since 6.10. Let's edit our init script with `sudo vi /etc/init/my_app.conf`
 
-```
+```text
 description "my_app"
 
 ## Uncomment the following two lines to run the
@@ -235,14 +235,14 @@ Along with the `start` command, exrm bundles a few others with our application t
 
 The `ping` command is a great sanity check when you need to ensure your application is running:
 
-```
+```console
 $ bin/my_app ping
 pong
 ```
 
 Or to see if it isn't:
 
-```
+```console
 $ bin/my_app ping
 Node 'my_app@127.0.0.1' not responding to pings.
 ```
@@ -251,7 +251,7 @@ Node 'my_app@127.0.0.1' not responding to pings.
 
 `remote_console` will be your friend when debugging is in order. It allows you to attach an IEx console to your running application. When closing the console, your application continues to run.
 
-```
+```console
 $ bin/my_app remote_console
 Erlang/OTP 17 [erts-6.1] [source-d2a4c20] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]
 
@@ -267,7 +267,7 @@ Although at the time of writing (25 Aug 2014) there is an [open issue with upgra
 
 You may run into situations where your application needs to stop. Look no further than the `stop` command.
 
-```
+```console
 $ bin/my_app stop
 ok
 ```
@@ -276,11 +276,11 @@ ok
 
 In a lot of cases, you're going to have more than one application running in your hosting environment, all of which might need to be accessible on port 80. Since only one application can listen on a single port at a time, we need to use something to proxy our application. You will typically see Apache (with `mod_proxy` enabled) or nginx used for this, and we'll be setting up nginx in this case.
 
-Let's create our config file for our application. By default, everything in `/etc/nginx/sites-enabled` is included into the main `/etc/nginx/nginx.conf` file that is used to configure nginx's runtime environment. Standard practice is to create our file in `/etc/nginx/sites-available` and make a symbolic link to it in `/etc/nginx/sites-enabled`. 
+Let's create our config file for our application. By default, everything in `/etc/nginx/sites-enabled` is included into the main `/etc/nginx/nginx.conf` file that is used to configure nginx's runtime environment. Standard practice is to create our file in `/etc/nginx/sites-available` and make a symbolic link to it in `/etc/nginx/sites-enabled`.
 
 > Note: These points hold true for Apache as well, but the steps to accomplish them are slightly different.
 
-```
+```console
 $ sudo touch /etc/nginx/sites-available/my_app
 $ sudo ln -s /etc/nginx/sites-available /etc/nginx/sites-enabled
 $ sudo vi /etc/nginx/sites-available/my_app
@@ -288,7 +288,7 @@ $ sudo vi /etc/nginx/sites-available/my_app
 
 Contents of our `/etc/nginx/sites-available/my_app` file:
 
-```
+```nginx
 upstream my_app {
     server 127.0.0.1:8888;
 }
@@ -310,4 +310,4 @@ server{
 
 Like our `upstart` script, this nginx config is basic. Look to the [nginx wiki](http://wiki.nginx.org/Main) for steps to configure any more involved features. Restart nginx with `sudo service nginx restart` to load our new config.
 
-At this point, we should be able to see our application if we visit `http://hostname.com/` if everything has been successful up to this point. 
+At this point, we should be able to see our application if we visit `http://hostname.com/` if everything has been successful up to this point.


### PR DESCRIPTION
This pull request add or correct the name of language for code block.  
The rules are followings.
- `html` if it includes html or eex tags.
- `elixir` if it includes iex session or mainly elixir code
- `console` if there are *nix commands and responses
- `nginx` if it is nginx configuration
- others are `text`
