### PR TITLE
Link Repair

### DIFF
--- a/0_overview.md
+++ b/0_overview.md
@@ -2,7 +2,7 @@
 
 Phoenix is a web development framework written in Elixir which implements the server-side MVC pattern. If you've ever used a similar framework, say Ruby on Rails or Python's Django, many of the concepts will be familiar to you. Phoenix is not, however, simply a Rails clone. It aims to have the best of both worlds, high developer productivity _and_ high application performance. Phoenix also has some interesting new twists, channels for managing Websockets, pre-compiled templates and the potential for alternative architectures which may make services more manageable from the very beginning of your project.
 
-If you are already familiar with Elixir, great! If not, there are a number of places you can go to learn. You might want to read through the [Elixir guides](http://elixir-lang.org/getting_started/1.html) first. You might also want to look through any of the books, blogs or videos listed in the [Resources Guide](/Z_resources.md).
+If you are already familiar with Elixir, great! If not, there are a number of places you can go to learn. You might want to read through the [Elixir guides](http://elixir-lang.org/getting_started/1.html) first. You might also want to look through any of the books, blogs or videos listed in the Resources Guide.
 
 The aim of this introductory guide is to present a brief, high level overview of Phoenix, the parts that make it up, and the layers underneath that support it.
 
@@ -44,7 +44,7 @@ Phoenix takes great advantage of Plug in general - the router and controllers es
 
 One of the most important things about Plug, is that it provides adapters to HTTP servers which will ultimately deliver application content to your users. Currently, Plug only provides an adapter to Cowboy, which we will talk about next, but there are plans to provide adapters for other servers in the future.
 
-Links to more in-depth information on Plug can be found in the [Resources Guide](/Z_resources.md).
+Links to more in-depth information on Plug can be found in the Resources Guide.
 
 ### Cowboy
 
@@ -60,4 +60,4 @@ Sheriff uses parse transforms for type based validation. Sheriff also validates 
 
 Cowboy has fantastic documentation. The Guides are especially helpful. Learning more about Cowboy will surely help you to understand of Phoenix more fully.
 
-Cowboy has its own section of links in the [Resources Guide](/Z_resources.md).
+Cowboy has its own section of links in the Resources Guide.

--- a/Z_resources.md
+++ b/Z_resources.md
@@ -1,62 +1,63 @@
 ##Elixir
 
-This is a selected list of resources to help you find your way with Elixir, Phoenix, and Erlang. For a more complete list of Elixir resources, please see the <a href="https://github.com/elixir-lang/elixir/wiki">Elixir Wiki</a>.
+This is a selected list of resources to help you find your way with Elixir, Phoenix, and Erlang. For a more complete list of Elixir resources, please see the [Elixir Wiki](https://github.com/elixir-lang/elixir/wiki).
 
-- <a href="http://elixir-lang.org/getting_started/1.html">Elixir Guides</a>
-- <a href="http://elixir-lang.org/docs/stable/elixir/">Official Documentation</a> (curent stable release)
-- <a href="https://hex.pm/">Hex Packages and Documentation</a>
+- [Elixir Guides](http://elixir-lang.org/getting_started/1.html)
+- [Official Documentation](http://elixir-lang.org/docs/stable/elixir) (curent stable release)
+- [Hex Packages and Documentation](https://hex.pm)
 
 #####The Erlangist: Understanding Elixir Macros, by Saša Jurić
-  - <a href="http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-1.html">Part 1</a>
-  - <a href="http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-2.html">Part 2</a>
-  - <a href="http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-3.html">Part 3</a>
-  - <a href="http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-4.html">Part 4</a>
-  - <a href="http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-5.html">Part 5</a>
+  - [Part 1](http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-1.html)
+  - [Part 2](http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-2.html)
+  - [Part 3](http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-3.html)
+  - [Part 4](http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-4.html)
+  - [Part 5](http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-5.html)
 
 #####Books
-  - <a href="http://pragprog.com/book/elixir/programming-elixir">Programming Elixir</a>, Dave Thomas
-  - <a href="http://www.manning.com/juric/">Elixir in Action</a>, Saša Jurić
-  - <a href="http://shop.oreilly.com/product/0636920030584.do">Introducing Elixir</a>, Simon St. Laurent, J. David Eisenberg
-  - <a href="https://pragprog.com/book/cmelixir/metaprogramming-elixir">Metaprogramming Elixir</a>, Chris McChord, coming in May 2015
+  - [Programming Elixir](http://pragprog.com/book/elixir/programming-elixir), Dave Thomas
+  - [Elixir in Action](http://www.manning.com/juric/), Saša Jurić
+  - [Introducing Elixir](http://shop.oreilly.com/product/0636920030584.do), Simon St. Laurent, J. David Eisenberg
+  - [Metaprogramming Elixir](https://pragprog.com/book/cmelixir/metaprogramming-elixir), Chris McChord, coming in May 2015
 
 ##Phoenix
-- <a href="https://github.com/phoenixframework/phoenix">The Phoenix Project</a>
-- <a href="http://api.phoenixframework.org/">Official Documentation</a> (current stable release)
+- [The Phoenix Project](https://github.com/phoenixframework/phoenix)
+- [Official Documentation](http://api.phoenixframework.org) (current stable release)
 
 #####Elixir Dose: Let's Build Web App With Phoenix And Ecto, by Riza Fahmi, edited by Augie De Blieck Jr.
-  - <a href="http://elixirdose.com/post/lets-build-web-app-with-phoenix-and-ecto">Part 1</a>
-  - <a href="http://elixirdose.com/post/phoenix-ecto-and-jobs-portal-project-part-2">Part 2</a>
-  - <a href="http://elixirdose.com/post/phoenix-ecto-and-jobs-portal-project-part-3">Part 3</a>
-  - <a href="http://elixirdose.com/post/phoenix-part-4-registration-and-login">Part 4</a>
+  - [Part 1](http://elixirdose.com/post/lets-build-web-app-with-phoenix-and-ecto)
+  - [Part 2](http://elixirdose.com/post/phoenix-ecto-and-jobs-portal-project-part-2)
+  - [Part 3](http://elixirdose.com/post/phoenix-ecto-and-jobs-portal-project-part-3)
+  - [Part 4](http://elixirdose.com/post/phoenix-part-4-registration-and-login)
+  - [Part 5](http://elixirdose.com/post/phoenix-flying-high-deploying-phoenix-the-final-part)
 
 #####Videos
-  - <a href="http://www.confreaks.com/videos/3488-railsconf-workshop-all-aboard-the-elixir-expresse">All Aboard The Elixir Express</a>, Chris McCord
-  - <a href="http://www.confreaks.com/videos/4132-elixirconf2014-rise-of-the-phoenix-building-an-elixir-web-framework">The Rise of the Phoenix</a>, Chris McCord
+  - [All Aboard The Elixir Express](http://www.confreaks.com/videos/3488-railsconf-workshop-all-aboard-the-elixir-expresse), Chris McCord
+  - [The Rise of the Phoenix](http://www.confreaks.com/videos/4132-elixirconf2014-rise-of-the-phoenix-building-an-elixir-web-framework), Chris McCord
 
 ##Plug
   The Elixir middleware layer Phoenix makes extensive use of.
-  - <a href="https://github.com/elixir-lang/plug">Source Code and Readme</a>
-  - <a href="http://hexdocs.pm/plug/0.8.1/">Documentation</a>
+  - [Source Code and Readme](https://github.com/elixir-lang/plug)
+  - [Documentation](http://hexdocs.pm/plug)
 
 ##EEX
   The default templating system for Phoenix.
-  - <a href="https://github.com/elixir-lang/elixir">Source Code and Readme</a>
-  - <a href="http://elixir-lang.org/docs/stable/eex/">Documentation</a>
+  - [Source Code and Readme](https://github.com/elixir-lang/elixir)
+  - [Documentation](http://elixir-lang.org/docs/stable/eex)
 
 ##Cowboy
   The webserver Phoenix is based on.
-  - <a href="https://github.com/ninenines/cowboy">Source Code and Readme</a>
-  - <a href="http://ninenines.eu/docs/en/cowboy/1.0/guide/">User Guides</a>
-  - <a href="http://ninenines.eu/docs/en/cowboy/1.0/manual/">Manual/Function Reference</a>
+  - [Source Code and Readme](https://github.com/ninenines/cowboy)
+  - [User Guides](http://ninenines.eu/docs/en/cowboy/1.0/guide/)
+  - [Manual/Function Reference](http://ninenines.eu/docs/en/cowboy/1.0/manual/)
 
 ##Erlang
-- <a href="http://www.erlang.org/doc/getting_started/users_guide.html">Erlang User Guide</a>
+- [Erlang User Guide](http://www.erlang.org/doc/getting_started/users_guide.html)
 
 #####Books
-- <a href="http://pragprog.com/book/jaerlang2/programming-erlang">Programming Erlang</a> 2nd Edition, Joe Armstrong
-- <a href="http://shop.oreilly.com/product/0636920025818.do">Introducing Erlang</a>, Simon St. Laurent
-- <a href="http://www.nostarch.com/erlang">Learn You Some Erlang for Great Good!</a>, Fred Hebert
-- <a href="http://www.manning.com/logan/">Erlang and OTP in Action</a>, Martin Logan, Eric Merritt, and Richard Carlsson
-- <a href="http://shop.oreilly.com/product/9780596518189.do">Erlang Programming</a>, Francesco Cesarini and Simon Thompson
-- <a href="http://shop.oreilly.com/product/0636920024149.do">Designing for Scalability with Erlang/OTP</a>, Francesco Cesarini, Steve Vinoski
-- <a href="http://www.erlang-in-anger.com/">Erlang in Anger</a>, Fred Hebert
+- [Programming Erlang](http://pragprog.com/book/jaerlang2/programming-erlang), 2nd Edition, Joe Armstrong
+- [Introducing Erlang](http://shop.oreilly.com/product/0636920025818.do), Simon St. Laurent
+- [Learn You Some Erlang for Great Good!](http://www.nostarch.com/erlang), Fred Hebert
+- [Erlang and OTP in Action](http://www.manning.com/logan/), Martin Logan, Eric Merritt, and Richard Carlsson
+- [Erlang Programming](http://shop.oreilly.com/product/9780596518189.do), Francesco Cesarini and Simon Thompson
+- [Designing for Scalability with Erlang/OTP](http://shop.oreilly.com/product/0636920024149.do), Francesco Cesarini, Steve Vinoski
+- [Erlang in Anger](http://www.erlang-in-anger.com/), Fred Hebert


### PR DESCRIPTION
- convert html anchors tags to markdown links
- remove broken resource guide links
