### PR TITLE
Wording Changes for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-###Welcome to the Proto-Phoenix-Guides!
+###Welcome to the Phoenix Guides!
 
-This is the workspace for what will become the actual Phoenix Guides. The material here is in an early stage of development. The formatting is minimal. The coverage is incomplete. There may be factual errors. But it is something, and it is available now.
+This is the workspace the official Phoenix Guides on [http://www.phoenixframework.org/](http://www.phoenixframework.org/). The material here is still a work in progress, but it is becoming more complete all the time.
 
-Phoenix is moving fast. Those of us who have contributed to these guides are doing our best to keep up with the changes. Wherever possible, we have noted differences between what works on the master branch and what works on the latest stable release. Still, we may miss things.
+Phoenix itself is moving fast. Those of us who have contributed to these guides are doing our best to keep up with the changes. Wherever possible, we have noted differences between what works on the master branch and what works on the latest stable release. Still, we may miss things.
 
 The good news is, we love pull requests! Please do submit additions or corrections. The guides will be better for us all.
 


### PR DESCRIPTION
Changes to reflect the launch of the readme.io site and the truncation of phoenixframework readme.md.

/cc @chrismccord how do you feel about the word "official" vs "actual" in the first sentence? I'm not sure I like either one, to be honest, but I feel like I need an adjective. :)
