### PR TITLE
Add channel testing guide

### DIFF
--- a/ZZ_testing_channels.md
+++ b/ZZ_testing_channels.md
@@ -12,21 +12,19 @@ make testing Channels easy.
 
 Let’s add a new file at `test/channels/room_channel_test.exs`
 
-```
-defmodule App.RoomChannelTest do
-  use ExUnit.Case
-  import Phoenix.Channel.Test
-  alias App.RoomChannel
+    defmodule App.RoomChannelTest do
+      use ExUnit.Case
+      import Phoenix.Channel.Test
+      alias App.RoomChannel
 
-  test "room:join requires the super secure auth token" do
-    {status, _socket} =
-      build_socket("room:join")
-      |> join(RoomChannel, %{"token" => "phoenix"}
+      test "room:join requires the super secure auth token" do
+        {status, _socket} =
+          build_socket("room:join")
+          |> join(RoomChannel, %{"token" => "phoenix"}
 
-    assert status == :ok
-  end
-end
-```
+        assert status == :ok
+      end
+    end
 
 So what’s happening here?
 
@@ -42,47 +40,41 @@ When we run `mix test` we see that we have not yet defined
 `App.RoomChannel`. Let’s get this test passing by creating a file at
 `web/channels/room_channel.ex`
 
-```
-defmodule App.RoomChannel do
-  use Phoenix.Channel
+    defmodule App.RoomChannel do
+      use Phoenix.Channel
 
-  def join("room:join", %{"token" => token}, socket) do
-    {:ok, socket}
-  end
-end
-```
+      def join("room:join", %{"token" => token}, socket) do
+        {:ok, socket}
+      end
+    end
 
 This will make our test pass, but it’s not quite what we need. Right now the
 Channel will authorize any socket. Let’s add a test to make sure that a
 channel will fail when the token is not correct.
 
-```
-  # Add this inside `App.RoomChannelTest`
+    # Add this inside `App.RoomChannelTest`
 
-  test "room:join returns unauthorized if token is not correct" do
-    {status, message, socket} =
-      build_socket(“room:join”)
-      |> join(RoomChannel, %{"token" => "Not correct"}
+    test "room:join returns unauthorized if token is not correct" do
+      {status, message, socket} =
+        build_socket(“room:join”)
+        |> join(RoomChannel, %{"token" => "Not correct"}
 
-    assert status == :error
-    assert message == :unauthorized
-  end
-```
+      assert status == :error
+      assert message == :unauthorized
+    end
 
 If we run mix test this will not pass since we haven't added any code. Let's
 fix that.
 
-```
-  # In `App.RoomChannel`
+    # In `App.RoomChannel`
 
-  def join("room:join", %{"token" => token}, socket) do
-    if token == "phoenix" do
-      {:ok, socket}
-    else
-      {:error, :unauthorized, socket}
+    def join("room:join", %{"token" => token}, socket) do
+      if token == "phoenix" do
+        {:ok, socket}
+      else
+        {:error, :unauthorized, socket}
+      end
     end
-  end
-```
 
 Now if we run `mix test` we will see that both tests pass. Nice job! Now you
 see how to test against
@@ -91,16 +83,14 @@ see how to test against
 
 Let's add some tests for handling incoming messages.
 
-```
-  # Add to `App.RoomChannelTest`
+    # Add to `App.RoomChannelTest`
 
-  test "room:info replies with the new room's info" do
-    build_socket("room:info")
-    |> handle_in(RoomChannel)
+    test "room:info replies with the new room's info" do
+      build_socket("room:info")
+      |> handle_in(RoomChannel)
 
-    assert_socket_replied("room:info", %{title: "Elixir/Phoenix discussion"})
-  end
-```
+      assert_socket_replied("room:info", %{title: "Elixir/Phoenix discussion"})
+    end
 
 We build a socket like we did before, but this time we call
 `Phoenix.Channel.handle_in` without any params. This will call the `handle_in`
@@ -114,29 +104,25 @@ encoded if you're connecting in the browser._
 
 Let's add this function to our `RoomChannel` to make this work
 
-```
-  def handle_in("room:info", _params, socket) do
-    reply socket, "room:info", %{title: "Elixir/Phoenix discussion"}
-  end
-```
+    def handle_in("room:info", _params, socket) do
+      reply socket, "room:info", %{title: "Elixir/Phoenix discussion"}
+    end
 
 ## Testing `handle_in` with `broadcast`
 
 
 Let's add some tests for handling incoming messages that broadcast
 
-```
-  # Add to `App.RoomChannelTest`
+    # Add to `App.RoomChannelTest`
 
-  test "room:new_chat broadcasts the chat message" do
-    chat_message = %{message: "I <3 Elixir"}
+    test "room:new_chat broadcasts the chat message" do
+      chat_message = %{message: "I <3 Elixir"}
 
-    build_socket("room:new_chat")
-    |> handle_in(RoomChannel, chat_message)
+      build_socket("room:new_chat")
+      |> handle_in(RoomChannel, chat_message)
 
-    assert_socket_broadcasted("room:new_chat", chat_message)
-  end
-```
+      assert_socket_broadcasted("room:new_chat", chat_message)
+    end
 
 This time we call the Channel with params for a new chat message and assert
 that the channel broadcasted a new chat with the correct payload (the new
@@ -145,10 +131,8 @@ was added.
 
 Let's add this function to our `RoomChannel` to make this work.
 
-```
-  def handle_in("room:new_chat", message_params, socket) do
-    # Code to create a new message in a database
+    def handle_in("room:new_chat", message_params, socket) do
+      # Code to create a new message in a database
 
-    broadcast socket, "room:new_chat", message_params
-  end
-```
+      broadcast socket, "room:new_chat", message_params
+    end

--- a/ZZ_testing_channels.md
+++ b/ZZ_testing_channels.md
@@ -9,10 +9,10 @@ make testing Channels easy.
 
 Let’s add a new file at `test/channels/room_channel_test.exs`
 
-    defmodule App.RoomChannelTest do
+    defmodule HelloPhoenix.RoomChannelTest do
       use ExUnit.Case
       import Phoenix.Channel.Test
-      alias App.RoomChannel
+      alias HelloPhoenix.RoomChannel
 
       test "room:join requires the super secure auth token" do
         {status, _socket} =
@@ -34,10 +34,10 @@ get the status of the response and check that it is `:ok` meaning that the
 socket is authorized.
 
 When we run `mix test` we see that we have not yet defined
-`App.RoomChannel`. Let’s get this test passing by creating a file at
+`HelloPhoenix.RoomChannel`. Let’s get this test passing by creating a file at
 `web/channels/room_channel.ex`
 
-    defmodule App.RoomChannel do
+    defmodule HelloPhoenix.RoomChannel do
       use Phoenix.Channel
 
       def join("room:join", %{"token" => token}, socket) do
@@ -49,7 +49,7 @@ This will make our test pass, but it’s not quite what we need. Right now the
 Channel will authorize any socket. Let’s add a test to make sure that a
 channel will fail when the token is not correct.
 
-    # Add this inside `App.RoomChannelTest`
+    # Add this inside `HelloPhoenix.RoomChannelTest`
 
     test "room:join returns unauthorized if token is not correct" do
       {status, message, socket} =
@@ -63,7 +63,7 @@ channel will fail when the token is not correct.
 If we run mix test this will not pass since we haven't added any code. Let's
 fix that.
 
-    # In `App.RoomChannel`
+    # In `HelloPhoenix.RoomChannel`
 
     def join("room:join", %{"token" => token}, socket) do
       if token == "phoenix" do
@@ -80,7 +80,7 @@ see how to test against
 
 Let's add some tests for handling incoming messages.
 
-    # Add to `App.RoomChannelTest`
+    # Add to `HelloPhoenix.RoomChannelTest`
 
     test "room:info replies with the new room's info" do
       build_socket("room:info")
@@ -109,13 +109,13 @@ Let's add this function to our `RoomChannel` to make this work
 
 Let's add some tests for handling incoming messages that broadcast
 
-    # Add to `App.RoomChannelTest`
+    # Add to `HelloPhoenix.RoomChannelTest`
 
     test "room:new_chat broadcasts the chat message" do
       chat_message = %{message: "I <3 Elixir"}
 
       build_socket("room:new_chat")
-      |> subscribe(App.PubSub)
+      |> subscribe(HelloPhoenix.PubSub)
       |> handle_in(RoomChannel, chat_message)
 
       assert_socket_broadcasted("room:new_chat", chat_message)
@@ -123,7 +123,7 @@ Let's add some tests for handling incoming messages that broadcast
 
 When building the socket we need to also make sure to subscribe to it, or else
 there will be no one to broadcast to and the test will fail. Typically the
-module you pass in is `NameOfYourApp.PubSub`.
+module you pass in is `NameOfYourHelloPhoenix.PubSub`.
 
 This time we call the Channel with params for a new chat message and assert
 that the channel broadcasted a new chat with the correct payload (the new
@@ -143,11 +143,11 @@ Let's add this function to our `RoomChannel` to make this work.
 What if we want to timestamp outgoing messages? Let's add a test and an
 implementation for that.
 
-    # Add to `App.RoomChannelTest`
+    # Add to `HelloPhoenix.RoomChannelTest`
 
     test "room:new_chat adds timestamp on the way out"
       build_socket("room:new_chat")
-      |> subscribe(App.PubSub)
+      |> subscribe(HelloPhoenix.PubSub)
       |> handle_out(RoomChannel, %{message: "foo"})
 
       assert_socket_replied("room:new_chat", %{message: "foo", time: "now!"})

--- a/ZZ_testing_channels.md
+++ b/ZZ_testing_channels.md
@@ -1,0 +1,154 @@
+Testing Phoenix Channels
+========================
+
+Testing Phoenix Channels will help ensure that your code continues to work
+as you make changes to your application. It helps guide development and
+ensure there is no breakage later on down the road.
+
+Phoenix has built in helper functions in `Phoenix.Channel.Test` that help
+make testing Channels easy.
+
+## Testing `join` authorization
+
+Let’s add a new file at `test/channels/room_channel_test.exs`
+
+```
+defmodule App.RoomChannelTest do
+  use ExUnit.Case
+  import Phoenix.Channel.Test
+  alias App.RoomChannel
+
+  test "room:join requires the super secure auth token" do
+    {status, _socket} =
+      build_socket("room:join")
+      |> join(RoomChannel, %{"token" => "phoenix"}
+
+    assert status == :ok
+  end
+end
+```
+
+So what’s happening here?
+
+First we’ve set this test up with `ExUnit` and imported the test helpers
+with `import Phoenix.Channel.Test`.
+
+Next, we build a socket with the topic `"room:join"` and join the
+`RoomChannel` with the params `%{"token" => "phoenix"}`. We pattern match to
+get the status of the response and check that it is `:ok` meaning that the
+socket is authorized.  
+
+When we run `mix test` we see that we have not yet defined
+`App.RoomChannel`. Let’s get this test passing by creating a file at
+`web/channels/room_channel.ex`
+
+```
+defmodule App.RoomChannel do
+  use Phoenix.Channel
+
+  def join("room:join", %{"token" => token}, socket) do
+    {:ok, socket}
+  end
+end
+```
+
+This will make our test pass, but it’s not quite what we need. Right now the
+Channel will authorize any socket. Let’s add a test to make sure that a
+channel will fail when the token is not correct.
+
+```
+  # Add this inside `App.RoomChannelTest`
+
+  test "room:join returns unauthorized if token is not correct" do
+    {status, message, socket} =
+      build_socket(“room:join”)
+      |> join(RoomChannel, %{"token" => "Not correct"}
+
+    assert status == :error
+    assert message == :unauthorized
+  end
+```
+
+If we run mix test this will not pass since we haven't added any code. Let's
+fix that.
+
+```
+  # In `App.RoomChannel`
+
+  def join("room:join", %{"token" => token}, socket) do
+    if token == "phoenix" do
+      {:ok, socket}
+    else
+      {:error, :unauthorized, socket}
+    end
+  end
+```
+
+Now if we run `mix test` we will see that both tests pass. Nice job! Now you
+see how to test against
+
+## Testing `handle_in` with `reply`
+
+Let's add some tests for handling incoming messages.
+
+```
+  # Add to `App.RoomChannelTest`
+
+  test "room:info replies with the new room's info" do
+    build_socket("room:info")
+    |> handle_in(RoomChannel)
+
+    assert_socket_replied("room:info", %{title: "Elixir/Phoenix discussion"})
+  end
+```
+
+We build a socket like we did before, but this time we call
+`Phoenix.Channel.handle_in` without any params. This will call the `handle_in`
+function of `RoomChannel` with the socket and the socket's topic.
+
+`assert_socket_replied` asserts that there was a reply with the topic
+"room:info" and payload `%{title: "Elixir/Phoenix discussion"}`
+
+_Note: that the payload will not be JSON encoded during the test, but will be
+encoded if you're connecting in the browser._
+
+Let's add this function to our `RoomChannel` to make this work
+
+```
+  def handle_in("room:info", _params, socket) do
+    reply socket, "room:info", %{title: "Elixir/Phoenix discussion"}
+  end
+```
+
+## Testing `handle_in` with `broadcast`
+
+
+Let's add some tests for handling incoming messages that broadcast
+
+```
+  # Add to `App.RoomChannelTest`
+
+  test "room:new_chat broadcasts the chat message" do
+    chat_message = %{message: "I <3 Elixir"}
+
+    build_socket("room:new_chat")
+    |> handle_in(RoomChannel, chat_message)
+
+    assert_socket_broadcasted("room:new_chat", chat_message)
+  end
+```
+
+This time we call the Channel with params for a new chat message and assert
+that the channel broadcasted a new chat with the correct payload (the new
+chat). We broadcast so that anyone on this channel will see that a new chat
+was added.
+
+Let's add this function to our `RoomChannel` to make this work.
+
+```
+  def handle_in("room:new_chat", message_params, socket) do
+    # Code to create a new message in a database
+
+    broadcast socket, "room:new_chat", message_params
+  end
+```

--- a/ZZ_testing_channels.md
+++ b/ZZ_testing_channels.md
@@ -126,7 +126,7 @@ there will be no one to broadcast to and the test will fail. Typically the
 module you pass in is `NameOfYourHelloPhoenix.PubSub`.
 
 This time we call the Channel with params for a new chat message and assert
-that the channel broadcasted a new chat with the correct payload (the new
+that the channel has broadcast a new chat with the correct payload (the new
 chat). We broadcast so that anyone on this channel will see that a new chat
 was added.
 

--- a/ZZ_testing_channels.md
+++ b/ZZ_testing_channels.md
@@ -110,7 +110,6 @@ Let's add this function to our `RoomChannel` to make this work
 
 ## Testing `handle_in` with `broadcast`
 
-
 Let's add some tests for handling incoming messages that broadcast
 
     # Add to `App.RoomChannelTest`
@@ -119,10 +118,15 @@ Let's add some tests for handling incoming messages that broadcast
       chat_message = %{message: "I <3 Elixir"}
 
       build_socket("room:new_chat")
+      |> subscribe(App.PubSub)
       |> handle_in(RoomChannel, chat_message)
 
       assert_socket_broadcasted("room:new_chat", chat_message)
     end
+
+When building the socket we need to also make sure to subscribe to it, or else
+there will be no one to broadcast to and the test will fail. Typically the
+module you pass in is `NameOfYourApp.PubSub`.
 
 This time we call the Channel with params for a new chat message and assert
 that the channel broadcasted a new chat with the correct payload (the new

--- a/ZZ_testing_channels.md
+++ b/ZZ_testing_channels.md
@@ -34,7 +34,7 @@ with `import Phoenix.Channel.Test`.
 Next, we build a socket with the topic `"room:join"` and join the
 `RoomChannel` with the params `%{"token" => "phoenix"}`. We pattern match to
 get the status of the response and check that it is `:ok` meaning that the
-socket is authorized.  
+socket is authorized.
 
 When we run `mix test` we see that we have not yet defined
 `App.RoomChannel`. Let’s get this test passing by creating a file at
@@ -140,3 +140,27 @@ Let's add this function to our `RoomChannel` to make this work.
 
       broadcast socket, "room:new_chat", message_params
     end
+
+## Testing `handle_out`
+
+What if we want to timestamp outgoing messages? Let's add a test and an
+implementation for that.
+
+    # Add to `App.RoomChannelTest`
+
+    test "room:new_chat adds timestamp on the way out"
+      build_socket("room:new_chat")
+      |> subscribe(App.PubSub)
+      |> handle_out(RoomChannel, %{message: "foo"})
+
+      assert_socket_replied("room:new_chat", %{message: "foo", time: "now!"})
+    end
+
+Let's create the function to handle this
+
+    def handle_out("room:new_chat", message, socket) do
+      reply socket, "room:new_chat", Map.put(socket, :time, "now!")
+    end
+
+This wraps up the introduction to testing channels in Phoenix
+With these helpers you should be able to

--- a/ZZ_testing_channels.md
+++ b/ZZ_testing_channels.md
@@ -1,6 +1,3 @@
-Testing Phoenix Channels
-========================
-
 Testing Phoenix Channels will help ensure that your code continues to work
 as you make changes to your application. It helps guide development and
 ensure there is no breakage later on down the road.
@@ -8,7 +5,7 @@ ensure there is no breakage later on down the road.
 Phoenix has built in helper functions in `Phoenix.Channel.Test` that help
 make testing Channels easy.
 
-## Testing `join` authorization
+### Testing `join` authorization
 
 Let’s add a new file at `test/channels/room_channel_test.exs`
 
@@ -79,7 +76,7 @@ fix that.
 Now if we run `mix test` we will see that both tests pass. Nice job! Now you
 see how to test against
 
-## Testing `handle_in` with `reply`
+### Testing `handle_in` with `reply`
 
 Let's add some tests for handling incoming messages.
 
@@ -108,7 +105,7 @@ Let's add this function to our `RoomChannel` to make this work
       reply socket, "room:info", %{title: "Elixir/Phoenix discussion"}
     end
 
-## Testing `handle_in` with `broadcast`
+### Testing `handle_in` with `broadcast`
 
 Let's add some tests for handling incoming messages that broadcast
 
@@ -141,7 +138,7 @@ Let's add this function to our `RoomChannel` to make this work.
       broadcast socket, "room:new_chat", message_params
     end
 
-## Testing `handle_out`
+### Testing `handle_out`
 
 What if we want to timestamp outgoing messages? Let's add a test and an
 implementation for that.


### PR DESCRIPTION
This is a WIP since the helpers have not yet been added https://github.com/phoenixframework/phoenix/pull/652 I figured I'd get started on the guide and modify things as the code changes in the referenced PR. I'd love feedback on this to make sure it makes sense.

I'm also not actually sure we need `handle_out` helpers since `handle_out` will be called when `broadcast` is called. So I think we just use the `handle_in` and `assert_socket_replied` helpers.