### PR TITLE
Fix all headings so they should render correctly on Phoenix website

### DIFF
--- a/B_adding_pages.md
+++ b/B_adding_pages.md
@@ -66,7 +66,7 @@ lib
 ```
 Enough prep, let's get on with our first new Phoenix page!
 
-###A New Route
+### A New Route
 
 Routes map unique HTTP verb/path pairs to controller/action pairs which will handle them. Phoenix generates a router file for us in new applications at `web/router.ex`. This is where we will be working for this section.
 
@@ -127,7 +127,7 @@ scope "/", HelloPhoenix do
 end
 ```
 
-###A New Controller
+### A New Controller
 
 Controllers are Elixir modules, and actions are Elixir functions defined in them. The purpose of actions is to gather any data and perform any tasks needed for rendering. Our route specifies that we need a `HelloPhoenix.HelloController` module with an `index/2` action.
 
@@ -154,7 +154,7 @@ Note: Using an atom as the template name will also work here, `render conn, :ind
 
 The modules responsible for rendering are views, and we'll make a new one of those next.
 
-###A New View
+### A New View
 
 Phoenix views have several important jobs. They render templates. They also act as a presentation layer for raw data from the controller, preparing it for use in a template. Functions which perform this transformation should go in a view.
 
@@ -168,7 +168,7 @@ defmodule HelloPhoenix.HelloView do
 end
 ```
 
-###A New Template
+### A New Template
 
 Phoenix templates are just that, templates into which data can be rendered. The standard templating engine Phoenix uses is eex, which stands for [Embedded Elixir](http://elixir-lang.org/docs/stable/eex/). All of our template files will have the `.eex` file extension.
 
@@ -188,13 +188,13 @@ Now that we've got the route, controller, view and template, we should be able t
 
 There are a couple of interesting things to notice about what we just did. We didn't need to stop and re-start the server while we made these changes. Yes, Phoenix has hot code re-loading! Also, even though our `index.html.eex` file consisted of only a single div tag, The page we get is a full html document. Our index template is rendered into the application layout - `web/templates/layout/application.html.eex`. If you open it, you'll see a tag that looks like this: `<%= @inner %>`, which is what injects our rendered template into the layout before the html is sent off to the browser.
 
-##Another New Page
+## Another New Page
 
 Let's add just a little complexity to our application. We're going to add a new page that will recognize a piece of the url, label it as a "messenger" and pass it through the controller into the template so our messenger can say hello.
 
 As we did last time, the first thing we'll do is create a new route.
 
-###A New Route
+### A New Route
 
 For this exercise, we're going to re-use the `HelloController` we just created and just add a new `show` action. We'll add a line just below our last route, like this.
 
@@ -211,7 +211,7 @@ Notice that we put the atom `:messenger` in the path. Phoenix will take whatever
 
 For example, if we point the browser at: [http://localhost:4000/hello/Frank](http://localhost:4000/hello/Frank), the value of ":messenger" will be "Frank".
 
-###A New Action
+### A New Action
 
 Requests to our new route will be handled by the `HelloPhoenix.HelloController` `show` action. We already have the controller at `web/controllers/hello_controller.ex`, so all we need to do is edit that file and add a `show` action to it. This time, we'll need to keep the params that get passed into the action so that we can pass the messenger to the template. To do that, we add this show function to the controller.
 
@@ -226,7 +226,7 @@ Within the body of the `show` action, we also pass a third argument into the ren
 
 It's good to remember that the keys to the params [Dict](http://elixir-lang.org/docs/stable/elixir/Dict.html) will always be strings.
 
-###A New Template
+### A New Template
 
 For the last piece of this puzzle, we'll need a new template. Since it is for the `show` action of the `HelloController`, it will go into the `web/templates/hello` directory and be called `show.html.eex`. It will look surprisingly like our `index.html.eex` template, except that we will need to display the name of our messenger.
 

--- a/C_routing.md
+++ b/C_routing.md
@@ -72,7 +72,7 @@ web/router.ex:1: warning: this clause cannot match because a previous clause at 
 Compiled web/router.ex
 ```
 
-###Examining Routes
+### Examining Routes
 
 Phoenix provides a great tool for investigating routes in an application, the mix task `phoenix.routes`.
 
@@ -86,7 +86,7 @@ The output tells us that any HTTP GET request for the root of the application wi
 
 `page_path` is an example of a what Phoenix calls a path helper, and we'll talk about those very soon.
 
-###Resources
+### Resources
 
 The router supports other macros besides those for HTTP verbs like `get`, `post` and `put`. The most important among them is `resources`, which expands out to eight clauses of the match function.
 
@@ -159,7 +159,7 @@ comment_path  POST    /comments                      HelloPhoenix.CommentControl
 comment_path  PATCH   /comments/:id                  HelloPhoenix.CommentController.update/2
               PUT     /comments/:id                  HelloPhoenix.CommentController.update/2
 ```
-###Path Helpers
+### Path Helpers
 
 Path helpers are functions which are dynamically defined on the `Router.Helpers` module for an individual application. For us, that is `HelloPhoenix.Router.Helpers`.  Their names are derived from the name of the controller used in the route definition. Our controller is `HelloPhoenix.PageController`, and `page_path` is the function which will return the path to the root of our application.
 
@@ -179,7 +179,7 @@ Please see the [View Guide](http://www.phoenixframework.org/docs/views) for more
 
 This pays off tremendously if we should ever have to change the path of our route in the router. Since the path helpers are built dynamically from the routes, any calls to `page_path` in our templates will still work.
 
-###More on Path Helpers
+### More on Path Helpers
 
 When we ran the `phoenix.routes` task for our user resource, it listed the `user_path` as the path helper function for each line of output. Here is what that translates to for each action.
 
@@ -225,7 +225,7 @@ Application endpoints will have their own guide soon. For now, think of them as 
 
 The `_url` functions will get the host, port, proxy port and ssl information needed to construct the full url from the configuration parameters set for each environment. We'll talk about configuration in more detail in its own guide. For now, you can take a look at `/config/dev.exs` file in your own project to see what those values are.
 
-###Nested Resources
+### Nested Resources
 
 It is also possible to nest resources in a Phoenix router. Let's say we also have a posts resource which has a one to many relationship with users. That is to say, a user can create many posts, and an individual post belongs to only one user. We can represent that by adding a nested route in `web/router.ex` like this.
 
@@ -264,7 +264,7 @@ iex> HelloPhoenix.Router.Helpers.user_post_path(Endpoint, :index, 42, active: tr
 "/users/42/posts?active=true"
 ```
 
-###Scoped Routes
+### Scoped Routes
 
 Scopes are a way to group routes under a common path prefix and scoped set of plug middleware. We might want to do this for admin functionality, APIs  and especially for versioned APIs. Let's say we have user generated reviews on a site, and that those reviews first need to be approved by an admin. The semantics of these resources are quite different, and they may not share the same controller, so we want to keep them separate.
 
@@ -586,7 +586,7 @@ post_path  PATCH   /posts/:id       AnotherApp.PostController.update/2
 post_path  DELETE  /posts/:id       AnotherApp.PostController.delete/2
 ```
 
-###Pipelines
+### Pipelines
 
 We have come quite a long way in this guide without talking about one of the first lines we saw in the router - `pipe_through :browser`. It's time to fix that.
 
@@ -596,7 +596,7 @@ Pipelines are simply plugs stacked up together in a specific order and given a n
 
 A newly generated Phoenix application defines two pipelines called `:browser` and `:api`. We'll get to those in a minute, but first we need to talk about the plug stack in the Endpoint plugs.
 
-#####The Endpoint Plugs
+##### The Endpoint Plugs
 
 Endpoints organize all the plugs common to every request, and apply them before dispatching into the router(s) with their underlying `:browser`, `:api`, and custom pipelines. The default Endpoint plugs do quite a lot of work. Here they are in order.
 
@@ -618,7 +618,7 @@ Endpoints organize all the plugs common to every request, and apply them before 
 
 - [Plug.Router](http://hexdocs.pm/plug/Plug.Router.html) - plugs a router into the request cycle
 
-#####The `:browser` and `:api` Pipelines
+##### The `:browser` and `:api` Pipelines
 
 Phoenix defines two other pipelines by default, `:browser` and `:api`. The router will invoke these after it matches a route, assuming we have called `pipe_through/1` with them in the enclosing scope.
 
@@ -745,7 +745,7 @@ end
 
 In general, the scoping rules for pipelines behave as you might expect. In this example, all routes will pipe through the `:browser` pipeline, because the `/` scope encloses all the routes. Only the `reviews` resources routes will pipe through the `:review_checks` pipeline, however, because we declare `pipe_through :review_checks` within the `/reviews` scope, where the `reviews` resources routes are.
 
-#####Creating New Pipelines
+##### Creating New Pipelines
 
 Phoenix allows us to create our own custom pipelines anywhere in the router. It couldn't be simpler. We just call the `pipeline/2` macro with an atom for the name of our new pipeline and a block with all the plugs we want in it.
 
@@ -773,7 +773,7 @@ defmodule HelloPhoenix.Router do
 end
 ```
 
-###Channel Routes
+### Channel Routes
 
 Channels are a very exciting, real-time component of the Phoenix framework. Channels handle incoming and outgoing messages broadcast over a socket for a given topic. Channel routes, then, need to match requests by socket and topic in order to dispatch to the correct channel. (For a more detailed description of channels and their behavior, please see the [Channel Guide](http://www.phoenixframework.org/docs/channels).)
 
@@ -885,7 +885,7 @@ socket "/another_ws", HelloPhoenix, via: [WebSocket] do
 end
 ```
 
-###Summary
+### Summary
 
 Routing is a big topic, and we have covered a lot of ground here. The important points to take away from this guide are:
 - Routes which begin with an HTTP verb name expand to a single clause of the match function.

--- a/E_views.md
+++ b/E_views.md
@@ -77,7 +77,7 @@ Now we can reload the page and view source to see what we have.
 
 Great, `page_path/2` evaluated to `/` as we would expect, and we didn't need to qualify it with `HelloPhoenix.View`.
 
-###More About Views
+### More About Views
 
 You might be wondering how views are able to work so closely with templates.
 
@@ -150,7 +150,7 @@ If we need only the rendered string, without the whole tuple, we can use the `re
    "\nThis is the message: "] | "Hello from the view!"]
   ```
 
-###A Word About Layouts
+### A Word About Layouts
 
 Layouts are just templates. They have a view, just like other templates. In a newly generated app, this is `web/views/layout_view.ex`. You may be wondering how the string resulting from a rendered view ends up inside a layout. That's a great question!
 
@@ -164,7 +164,7 @@ If we look at `web/templates/layout/application.html.eex`, just about in the mid
 
 This is where the rendered string from the template will be placed.
 
-###The ErrorView
+### The ErrorView
 
 Phoenix recently added a new view to every generated application, the `ErrorView` which lives in `web/views/error_view.ex`. The purpose of the `ErrorView` is to handle two of the most common errors - `404 not found` and `500 internal error` - in a general way, from one centralized location. Let's see what it looks like.
 

--- a/F_templates.md
+++ b/F_templates.md
@@ -4,7 +4,7 @@ EEx is the default template system in Phoenix, and it is quite similar to ERB in
 
 As we learned in the [View Guide](http://www.phoenixframework.org/docs/views), by default, templates live in the `web/templates` directory, organized into directories named after a view. Each directory has its own view module to render the templates in it. We can change the template root directory by specifying a new one in the `root: "web/templates"` declaration in the main application view.
 
-###Examples
+### Examples
 
 We've already seen several ways in which templates are used, notably in the [Adding Pages Guide](http://www.phoenixframework.org/docs/adding-pages) and the [Views Guide](http://www.phoenixframework.org/docs/views). We may cover some of the same territory here, but we will certainly add some new information.
 

--- a/H_ecto-models.md
+++ b/H_ecto-models.md
@@ -151,7 +151,7 @@ Indexes:
 
 Notice that we do get an `id` column as our primary key by default, even though it isn't listed as a field in our migration.
 
-####The Repo
+#### The Repo
 
 Our `HelloPhoenix.Repo` module is the foundation we need to work with databases in a Phoenix application. Phoenix generated it for us here `lib/hello_phoenix/repo.ex`, and this is what it looks like.
 
@@ -180,7 +180,7 @@ It begins by configuring our `otp_app` name and repo module. Then it sets the ad
 
 We also have similar configuration in `config/test.exs` and `config/prod.secret.exs` which can also be changed to match our actual credentials.
 
-####The Model
+#### The Model
 
 Ecto models have several functions. Each model defines the fields of our schema as well as their types. They each define a struct with the same fields in our schema. Models are where we define relationships with other models. Our `User` model might have many `Post` models, and each `Post` would belong to a `User`. Models also handle data validation and type casting with changesets.
 
@@ -218,7 +218,7 @@ end
 
 The schema block at the top of the model should be pretty self-explanatory. We'll take a look at changesets next.
 
-####Changesets and Validations
+#### Changesets and Validations
 
 Changesets define a pipeline of transformations our data needs to undergo before it will be ready for our application to use. These transformations might include type casting, validation, and filtering out any extraneous parameters.
 
@@ -392,7 +392,7 @@ Email has invalid format
 
 There are many more validations and transformations we can perform in a changeset. Please see the [Ecto Changeset documentation](http://hexdocs.pm/ecto/Ecto.Changeset.html) for more information.
 
-####Controller Usage
+#### Controller Usage
 
 At this point, let's see how we can actually use Ecto in our application. Luckily, Phoenix gave us an example of this when we ran `mix phoenix.gen.html`, the `HelloPhoenix.UserController`.
 

--- a/J_config.md
+++ b/J_config.md
@@ -1,10 +1,10 @@
-#This Guide is Under Construction
+# This Guide is Under Construction
 
-####In the meantime, these links might help.
+#### In the meantime, these links might help.
 
 - [Phoenix Readme on Configuration](https://github.com/phoenixframework/phoenix#configuration)
 
-####Back of the Napkin Guess At Topics to Cover
+#### Back of the Napkin Guess At Topics to Cover
 
 - configuration - description
   - router

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###Welcome to the Phoenix Guides!
+### Welcome to the Phoenix Guides!
 
 This is the workspace for the official Phoenix Guides on [http://www.phoenixframework.org/](http://www.phoenixframework.org/). The material here is still a work in progress, but it is becoming more complete all the time.
 
@@ -6,6 +6,6 @@ Phoenix itself is moving fast. Those of us who have contributed to these guides 
 
 The good news is, we love pull requests! Please do submit additions or corrections. The guides will be better for us all.
 
-#####In Case You Were Wondering:
+##### In Case You Were Wondering:
 
 The non-standard 'A_filename' format is intended to roughly show the order the guides should appear when there is a site with actual navigation.

--- a/X_mix-tasks.md
+++ b/X_mix-tasks.md
@@ -1,6 +1,6 @@
 There are currently a number of built-in Phoenix-specific and ecto-specific mix tasks available to us within a newly-generated application. We can also create our own application specific tasks.
 
-##Phoenix Specific Mix Tasks
+## Phoenix Specific Mix Tasks
 
 ```console
 $ mix help | grep -i phoenix
@@ -11,7 +11,7 @@ mix phoenix.server       # Starts applications and their servers
 ```
 We have seen all of these at one point or another in the guides, but having all the information about them in one place seems like a good idea. And here we are.
 
-####`mix phoenix.new`
+#### `mix phoenix.new`
 
 This is how we tell Phoenix the framework to generate a new Phoenix application for us. We saw it early on in the [Up and Running Guide](http://www.phoenixframework.org/docs/up-and-running)
 
@@ -195,7 +195,7 @@ defmodule HelloPhoenix.Mixfile do
 . . .
 ```
 
-####`mix phoenix.gen.html`
+#### `mix phoenix.gen.html`
 
 Phoenix now offers the ability to generate all the code to stand up a complete HTML resource - ecto migration, ecto model, controller with all the necessary actions, view, and templates. This can be a tremendous timesaver. Let's take a look at how to make this happen.
 
@@ -238,7 +238,7 @@ Compiled web/models/post.ex
 (stdlib) erl_eval.erl:657: :erl_eval.do_apply/6
 ```
 
-####`mix phoenix.routes`
+#### `mix phoenix.routes`
 
 This task has a single purpose, to show us all the routes defined for a given router. We saw it used extensively in the [Routing Guide](http://www.phoenixframework.org/docs/routing).
 
@@ -255,7 +255,7 @@ $ mix phoenix.routes TaskTester.Router
 page_path  GET  /  TaskTester.PageController.index/2
 ```
 
-####`mix phoenix.server`
+#### `mix phoenix.server`
 
 This is the task we use to get our application running. It takes no arguments at all. If we pass any in, they will be silently ignored.
 
@@ -286,7 +286,7 @@ Interactive Elixir (1.0.2) - press Ctrl+C to exit (type h() ENTER for help)
 iex(1)>
 ```
 
-##Ecto Specific Mix Tasks
+## Ecto Specific Mix Tasks
 
 Newly generated Phoenix applications now include ecto and postgrex as dependencies by default (which is to say, unless we use the `--no-ecto` flag with `phoenix.new`). With those dependencies come mix tasks to take care of common ecto operations. Let's see which tasks we get out of the box.
 
@@ -302,7 +302,7 @@ mix ecto.rollback        # Reverts migrations down on a repo
 
 Note: We can run any of the tasks above with the `--no-start` flag to execute the task without starting the application.
 
-####`ecto.create`
+#### `ecto.create`
 This task will create the database specified in our repo. By default it will look for the repo named after our application (the one generated with our app unless we opted out of ecto), but we can pass in another repo if we want.
 
 Here's what it looks like in action.
@@ -361,7 +361,7 @@ To fix this, we need to change the permissions on our "postgres" user to allow d
 ALTER ROLE
 ```
 
-####`ecto.drop`
+#### `ecto.drop`
 
 This task will drop the database specified in our repo. By default it will look for the repo named after our application (the one generated with our app unless we opted out of ecto). It will not prompt us to check if we're sure we want to drop the db, so do exercise caution.
 
@@ -377,7 +377,7 @@ $ mix ecto.drop -r OurCustom.Repo
 The database for repo OurCustom.Repo has been dropped.
 ```
 
-####`ecto.gen.repo`
+#### `ecto.gen.repo`
 
 Many applications require more than one data store. For each data store, we'll need a new repo, and we can generate them automatically with `ecto.gen.repo`.
 
@@ -425,7 +425,7 @@ children = [
 . . .
 ```
 
-####`ecto.gen.migration`
+#### `ecto.gen.migration`
 
 Migrations are a programmatic, repeatable way to affect changes to a database schema. Migrations are also just modules, and we can create them with the `ecto.gen.migration` task. Let's walk through the steps to create a migration for a new comments table.
 
@@ -478,7 +478,7 @@ For more infomation on ecto's migration dsl, please see the [ecto migration docs
 
 That's it! We're ready to run our migration.
 
-####`ecto.migrate`
+#### `ecto.migrate`
 
 Once we have our migration module ready, we can simply run `mix ecto.migrate` to have our changes applied to the database.
 
@@ -536,7 +536,7 @@ The `--to` option will behave the same way.
 mix ecto.migrate --to 20150317170448
 ```
 
-####`ecto.rollback`
+#### `ecto.rollback`
 
 The `ecto.rollback` task will reverse the last migration we have run, undoing the schema changes. `ecto.migrate` and `ecto.rollback` are mirror images of each other.
 
@@ -549,7 +549,7 @@ $ mix ecto.rollback
 
 `ecto.rollback` will handle the same options as `ecto.migrate`, so `-n`, `--step`, `-v`, and `--to` will behave as they do for `ecto.migrate`.
 
-##Creating Our Own Mix Tasks
+## Creating Our Own Mix Tasks
 
 As we've seen throughout this guide, both mix itself and the dependencies we bring in to our application provide a number of really useful tasks for free. Since neither of these could possibly anticipate all our individual application's needs, mix allows us to create our own custom tasks. That's exactly what we are going to do now.
 


### PR DESCRIPTION
Headings should have a space between the # and the content, or they won't
render correctly on the Phoenix framework website.