### PR TITLE
Add some <kbd> tags in the "Up and running" guide

### DIFF
--- a/A_up_and_running.md
+++ b/A_up_and_running.md
@@ -82,6 +82,6 @@ By default Phoenix accepts requests on port 4000. If we point our favorite web b
 
 If your screen looks like the image above, congratulations! You now have working Phoenix application.
 
-Locally, our application is running in an iex session. To stop it, we hit ctrl-c twice, just as we would to stop iex normally.
+Locally, our application is running in an IEx session. To stop it, we hit <kbd>ctrl</kbd>-<kbd>c</kbd> twice, just as we would to stop IEx normally.
 
 The next step is customizing our application just a bit to give us a sense of how a Phoenix app is put together.


### PR DESCRIPTION
If there's an HTML tag I absolutely love is the [`<kbd>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd) tag for keyboard shortcuts :). As far as I can tell, there's no way of building the Phoenix guide locally (because readme.io) so I'm not sure if the `<kbd>` tag is already styled or needs custom styling; that's why I only added one of these tags, so that I can get some feedback before digging through the rest of the guides to find other places where we could use it.

Let me know :)

PS if you think using `<kbd>` tags is a bit of an overkill, don't worry, I get it :)