### PR TITLE
Fixing locale example to set conn var

### DIFF
--- a/DD_Plug.md
+++ b/DD_Plug.md
@@ -125,7 +125,7 @@ defmodule HelloPhoenix.Plugs.Locale
 
   def init(default), do: default
 
-  def call(%Plug.Conn{params: %{"locale" => loc}}, _default) when loc in @locales do
+  def call(%Plug.Conn{params: %{"locale" => loc}} = conn, _default) when loc in @locales do
     assign(conn, :locale, loc)
   end
   def call(conn, default), do: assign(conn, :locale, default)


### PR DESCRIPTION
Tho, I'm not sure what the indentation policy is for 90 char lines.