### PR TITLE
Add nginx upgrade headers to prevent cutting connection.

### DIFF
--- a/deployment/I_exrm_releases
+++ b/deployment/I_exrm_releases
@@ -441,6 +441,10 @@ These are the contents of our `/etc/nginx/sites-available/hello_phoenix` file.
 upstream hello_phoenix {
     server 127.0.0.1:8888;
 }
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
 server{
     listen 80;
     server_name .hostname.com;
@@ -452,6 +456,8 @@ server{
     location @proxy {
         include proxy_params;
         proxy_redirect off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
         proxy_pass http://hello_phoenix;
     }
 }

--- a/deployment/I_exrm_releases
+++ b/deployment/I_exrm_releases
@@ -441,6 +441,8 @@ These are the contents of our `/etc/nginx/sites-available/hello_phoenix` file.
 upstream hello_phoenix {
     server 127.0.0.1:8888;
 }
+# The following map statement is required 
+# if you plan to support channels. See http://nginx.com/blog/websocket-nginx/
 map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
@@ -456,9 +458,12 @@ server{
     location @proxy {
         include proxy_params;
         proxy_redirect off;
+        proxy_pass http://hello_phoenix;
+        # The following two headers need to be set in order 
+        # to keep the websocket connection open. Otherwise you'll see
+        # HTTP 400's being returned from websocket connections.
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        proxy_pass http://hello_phoenix;
     }
 }
 ```


### PR DESCRIPTION
I had trouble getting nginx not to cut the connection and return a 400 to the client without the following `Upgrade` and `Connection` headers. 