### PR TITLE
Sync with 0.14 release

### DIFF
--- a/B_adding_pages.md
+++ b/B_adding_pages.md
@@ -137,14 +137,12 @@ To make that happen, let's create a new `web/controllers/hello_controller.ex` fi
 defmodule HelloPhoenix.HelloController do
   use HelloPhoenix.Web, :controller
 
-  plug :action
-
   def index(conn, _params) do
     render conn, "index.html"
   end
 end
 ```
-We'll save a discussion of `use HelloPhoenix.Web, :controller` and `plug :action` for the [Controllers Guide](http://www.phoenixframework.org/docs/controllers). For now, let's focus on the `index/2` action.
+We'll save a discussion of `use HelloPhoenix.Web, :controller` for the [Controllers Guide](http://www.phoenixframework.org/docs/controllers). For now, let's focus on the `index/2` action.
 
 All controller actions take two arguments. The first is `conn`, a struct which holds a ton of data about the request. The second is `params`, which are the request parameters. Here, we are not using `params`, and we avoid compiler warnings by adding the leading `_`.
 

--- a/DD_Plug.md
+++ b/DD_Plug.md
@@ -27,7 +27,6 @@ defmodule HelloPhoenix.MessageController do
 
   plug :put_headers, %{content_encoding: "gzip", cache_control: "max-age=3600"}
   plug :put_layout, "bare.html"
-  plug :action
 
   ...
 end
@@ -69,7 +68,6 @@ defmodule HelloPhoenix.MessageController do
   plug :authenticate
   plug :find_message
   plug :authorize_message
-  plug :action
 
   def show(conn, params) do
     render conn, :show, page: find_message(params["id"])
@@ -84,7 +82,7 @@ defmodule HelloPhoenix.MessageController do
     end
   end
 
-  defp find_message(conn, _) do  
+  defp find_message(conn, _) do
     case find_message(params["id"]) do
       nil ->
         conn |> put_flash("That message wasn't found") |> redirect(to: "/") |> halt

--- a/introduction/E_installation.md
+++ b/introduction/E_installation.md
@@ -27,7 +27,7 @@ Once we have Elixir and Erlang, we are ready to install the Phoenix mix archive.
 Here's the command to install the Phoenix archive.
 
 ```console
-$ mix archive.install https://github.com/phoenixframework/phoenix/releases/download/v0.13.1/phoenix_new-0.13.1.ez
+$ mix archive.install https://github.com/phoenixframework/phoenix/releases/download/v0.14.0/phoenix_new-0.14.0.ez
 ```
 > Note: if the Phoenix archive won't install properly with this command, we can download the file directly from our browser, save it to the filesystem, and then run: `mix archive.install /path/to/local/phoenix_new.ez`.
 


### PR DESCRIPTION
0.14 release is imminent and I believe I addressed all relevant changes. @lancehalvorsen we did away with `plug :action` and thus `plug :render`, so I reworked the examples around this. You might want to double check the flow. Thanks!
