### PR TITLE
Fix missing plug:action in Hello Controller

### DIFF
--- a/B_adding_pages.md
+++ b/B_adding_pages.md
@@ -137,6 +137,8 @@ To make that happen, let's create a new `web/controllers/hello_controller.ex` fi
 defmodule HelloPhoenix.HelloController do
   use HelloPhoenix.Web, :controller
 
+  plug :action
+
   def index(conn, _params) do
     render conn, "index.html"
   end


### PR DESCRIPTION
Hi, I was getting my feet wet with Phoenix.
Following the Add Pages guide I got the following error.
    
    (RuntimeError) could not compile HelloPhoenix.HelloController because it does not have plug :action in its pipeline

In the generated Controller there is a     

   
    plug :action

I guessed the same thing would fix the new Controller, and it did(for me).
