### PR TITLE
Replace all occurrences of 'application.html.eex' with 'app.html.eex'

### DIFF
--- a/B_adding_pages.md
+++ b/B_adding_pages.md
@@ -23,7 +23,7 @@ Most of our work in this guide will be in the `web` directory, which looks like 
 ├── router.ex
 ├── templates
 │   ├── layout
-│   │   └── application.html.eex
+│   │   └── app.html.eex
 │   └── page
 │       └── index.html.eex
 └── views
@@ -184,7 +184,7 @@ Now that we've got the route, controller, view and template, we should be able t
 
 ![Phoenix Greets Us](/images/hello-from-phoenix.png)
 
-There are a couple of interesting things to notice about what we just did. We didn't need to stop and re-start the server while we made these changes. Yes, Phoenix has hot code re-loading! Also, even though our `index.html.eex` file consisted of only a single div tag, The page we get is a full html document. Our index template is rendered into the application layout - `web/templates/layout/application.html.eex`. If you open it, you'll see a tag that looks like this: `<%= @inner %>`, which is what injects our rendered template into the layout before the html is sent off to the browser.
+There are a couple of interesting things to notice about what we just did. We didn't need to stop and re-start the server while we made these changes. Yes, Phoenix has hot code re-loading! Also, even though our `index.html.eex` file consisted of only a single div tag, The page we get is a full html document. Our index template is rendered into the application layout - `web/templates/layout/app.html.eex`. If you open it, you'll see a tag that looks like this: `<%= @inner %>`, which is what injects our rendered template into the layout before the html is sent off to the browser.
 
 ## Another New Page
 

--- a/E_views.md
+++ b/E_views.md
@@ -18,7 +18,7 @@ That's simple enough. There's only one line, `use HelloPhoenix.Web, :view`. This
 
 At the top of this file, we mentioned that views are a place to put functions for use in our templates. Let's experiment with that a little bit.
 
-Let's open up our application layout template, `templates/layout/application.html.eex`, and change this line,
+Let's open up our application layout template, `templates/layout/app.html.eex`, and change this line,
 
 ```html
 <title>Hello Phoenix!</title>
@@ -156,7 +156,7 @@ Layouts are just templates. They have a view, just like other templates. In a ne
 
 When a template is rendered, the layout view will assign `@inner` with the rendered contents of the template. For HTML templates, `@inner` will be always marked as safe.
 
-If we look at `web/templates/layout/application.html.eex`, just about in the middle of the `<body>`, we will see this.
+If we look at `web/templates/layout/app.html.eex`, just about in the middle of the `<body>`, we will see this.
 
 ```html
 <%= @inner %>

--- a/G_channels.md
+++ b/G_channels.md
@@ -112,7 +112,7 @@ In your `web/templates/page/index.html.eex`, add a container to hold our chat me
 <input id="chat-input" type="text"></input>
 ```
 
-We'll also add jQuery to our application layout in `web/templates/layout/application.html.eex`:
+We'll also add jQuery to our application layout in `web/templates/layout/app.html.eex`:
 
 ```html
   ...

--- a/bonus_guides/D_mix_tasks.md
+++ b/bonus_guides/D_mix_tasks.md
@@ -99,7 +99,7 @@ $  mix phoenix.new task_tester --app hello_phoenix
 * creating task_tester/test/support/channel_case.ex
 * creating task_tester/test/test_helper.exs
 * creating task_tester/web/controllers/page_controller.ex
-* creating task_tester/web/templates/layout/application.html.eex
+* creating task_tester/web/templates/layout/app.html.eex
 * creating task_tester/web/templates/page/index.html.eex
 * creating task_tester/web/views/error_view.ex
 * creating task_tester/web/views/layout_view.ex
@@ -160,7 +160,7 @@ $  mix phoenix.new task_tester --module HelloPhoenix
 * creating task_tester/test/support/channel_case.ex
 * creating task_tester/test/test_helper.exs
 * creating task_tester/web/controllers/page_controller.ex
-* creating task_tester/web/templates/layout/application.html.eex
+* creating task_tester/web/templates/layout/app.html.eex
 * creating task_tester/web/templates/page/index.html.eex
 * creating task_tester/web/views/error_view.ex
 * creating task_tester/web/views/layout_view.ex


### PR DESCRIPTION
Sorry for not doing that [before](https://github.com/phoenixframework/phoenix_guides/pull/306). This PR replaces all occurrences of `application.html.eex`.