### PR TITLE
Update Upstart script to add app HOME.

### DIFF
--- a/deployment/I_exrm_releases
+++ b/deployment/I_exrm_releases
@@ -411,6 +411,10 @@ export MIX_ENV
 #env PORT=8888
 #export PORT
 
+## Add app HOME directory.
+env HOME /app
+export HOME
+
 
 pre-start exec /bin/sh /app/bin/hello_phoenix start
 


### PR DESCRIPTION
In the documentation under Deployment, in the section showing the Upstart script (http://www.phoenixframework.org/docs/advanced-deployment#section-setting-up-our-init-system), the Upstart script also requires definition of the app HOME, otherwise the app won't start under Upstart. I have just experienced this bug myself, and it has also been reported elsewhere (see bitwalker/exrm#61). The Upstart script needs the following additions (using the directory from the doc example):

    env HOME=/app
    export HOME
