### PR TITLE
Note that io.js is not known to work in place of node.js

### DIFF
--- a/introduction/E_installation.md
+++ b/introduction/E_installation.md
@@ -45,6 +45,8 @@ We can get node.js from the [download page](https://nodejs.org/download/). When 
 
 Mac OS X users can also install node.js via [homebrew](http://brew.sh/).
 
+Note: io.js, which is an npm compatible platform originally based on Node.js, is not known to work with Phoenix.
+
 Debin/Ubuntu users might see an error that looks like this:
 ```console
 sh: 1: node: not found


### PR DESCRIPTION
A Windows user had trouble with this. It wasn't clear that their installation of io.js would not be sufficient to get Phoenix to work, even though it says it is npm compatible.

(We did not try to debug why io.js wasn't working, the user simply installed node.js and went on.  It's possible it *might* work, if someone puts in the time to figure it out.)