### PR TITLE
Heroku: Add note on setting HOST and PORT config vars

### DIFF
--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -180,6 +180,12 @@ Setting config vars and restarting mysterious-meadow-6277... done, v3
 SECRET_KEY_BASE: my_secret_key_base
 ```
 
+You will also need to define the `HOST` and `PORT` configs at this time:
+
+```console
+$ heroku config:set HOST=mysterious-meadow-6277.herokuapp.com PORT=80
+```
+
 ## Deploy Time!
 
 Our project is now ready to be deployed on Heroku.


### PR DESCRIPTION
When following the Heroku directions, I couldn't get my app to boot without first setting the `HOST` and `PORT` env vars.

I added a note to this effect, but I'm not sure if there's a better/more dynamic way of retrieving these from the Heroku environment without having to set them manually.