### PR TITLE
import socket from deps/phoenix/web/static/js/phoenix

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -104,6 +104,8 @@ For our chat app, we'll allow anyone to join the `"rooms:lobby"` topic, but any 
 With our channel in place, lets head over to `web/static/js/app.js` and get the client and server talking.
 
 ```javascript
+import {Socket} from "deps/phoenix/web/static/js/phoenix"
+
 let socket = new Socket("/socket")
 socket.connect()
 let chan = socket.channel("rooms:lobby", {})


### PR DESCRIPTION
Without `import {Socket} from "deps/phoenix/web/static/js/phoenix"` in app.js, the browser console will raise:
```
ReferenceError: Can't find variable Socket
```
While importing directly into app.js seems to be the simplest solution, you could also:
```
import socket from "./socket"
```
Though I believe this would require a bit more tinkering and code rewriting to get it to work (a tad over my head right now).

Issues I've ran into with the alternative method - importing socket.js into app.js:

1. line 57 `let channel = socket.channel("topic:subtopic", {})` errors because of an unmatched topic.  Simple fix, just change the topic to: `"rooms:lobby"`
2. Looks like it's expecting a token.  A little over my head for this early in the docs :)
```
[Error] WebSocket connection to 'ws://localhost:4000/socket/websocket?token=undefined' 
failed: WebSocket is closed before the connection is established.
	disconnect (app.js, line 600)
	connect (app.js, line 615)
	(anonymous function) (app.js, line 1149)
	initModule (app.js, line 64)
	require (app.js, line 74)
	global code (app.js, line 1242)
```