### PR TITLE
Add table name to references

### DIFF
--- a/H_ecto_models.md
+++ b/H_ecto_models.md
@@ -520,7 +520,7 @@ That's the end of our walk-through of Ecto usage in our controller actions. Ther
 Suppose we are building a very simple video-sharing web application, in addition to having users on our site, we might also want to have videos. We asked Phoenix to scaffold a `Video` model for us:
 
 ```console
-$ mix phoenix.gen.model Video videos name:string approved_at:datetime description:text likes:integer views:integer user:references
+$ mix phoenix.gen.model Video videos name:string approved_at:datetime description:text likes:integer views:integer user:references:users
 * creating priv/repo/migrations/20150611051558_create_video.exs
 * creating web/models/video.ex
 * creating test/models/video_test.exs


### PR DESCRIPTION
Update the example mix command to include the table name after references, otherwise mix will generate the error:

```
** (Mix) Phoenix generators expect the table to be given to user:references.
For example:

    mix phoenix.gen.model Comment comments body:text post_id:references:posts
```