### PR TITLE
Add instructions for Procfile

### DIFF
--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -164,6 +164,12 @@ config :hello_phoenix, HelloPhoenix.Repo,
   url: System.get_env("DATABASE_URL"),
   pool_size: 20
 ```
+## Adding a Procfile to our Project
+A `Procfile` is a mechanism for declaring what commands are run by Heroku. Our Procfile for phoenix should look like this:
+
+```
+web: mix phoenix.server
+```
 
 ## Creating Environment Variables in Heroku
 

--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -165,7 +165,7 @@ config :hello_phoenix, HelloPhoenix.Repo,
   pool_size: 20
 ```
 ## Adding a Procfile to our Project
-A `Procfile` is a mechanism for declaring what commands are run by Heroku. Our Procfile for phoenix should look like this:
+A `Procfile` is a mechanism for declaring what commands are run by Heroku. In our Procfile we need to declare a web worker that starts our phoenix server:
 
 ```
 web: mix phoenix.server


### PR DESCRIPTION
Without a Procfile the buildpack is booting our application with `mix run --no-halt`.

```
2015-08-18T09:53:07.548572+00:00 heroku[web.1]: State changed from crashed to starting
2015-08-18T09:53:13.356381+00:00 heroku[web.1]: Starting process with command `mix run --no-halt`
2015-08-18T09:54:13.939913+00:00 heroku[web.1]: Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch
2015-08-18T09:54:13.940115+00:00 heroku[web.1]: Stopping process with SIGKILL
2015-08-18T09:54:14.768929+00:00 heroku[web.1]: Process exited with status 137
2015-08-18T09:54:15.723173+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=xxx.herokuapp.com request_id=a00d287b-c1ff-477d-b088-78ffa567242f fwd="78.34.35.189" dyno= connect= service= status=503 bytes=
```