### PR TITLE
add callbacks to example socket

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -73,7 +73,12 @@ defmodule HelloPhoenix.UserSocket do
   use Phoenix.Socket
 
   channel "rooms:*", HelloPhoenix.RoomChannel
-  ...
+
+  transport :websocket, Phoenix.Transports.WebSocket
+
+  def connect(_params, socket), do: {:ok, socket}
+
+  def id(_socket), do: nil
 end
 ```
 


### PR DESCRIPTION
A few colleagues came to me asking why their websocket didn't work. They followed the guide to the letter, but in the `web/channels/user_socket.ex` example file, we omit the required callbacks and `transport` setting. This PR simply includes those missing bits of code so that a new user can follow the channel guide and get a working websocket implementation up and running without having to look for the code represented by the `...`.