### PR TITLE
Add note about displaying custom errors.

### DIFF
--- a/bonus_guides/M_custom_errors.md
+++ b/bonus_guides/M_custom_errors.md
@@ -26,7 +26,7 @@ defmodule HelloPhoenix.ErrorView do
 end
 ```
 
-> NOTE: In the development environment, this behavior will be overridden. Instead, we will get a really great debugging page. In order to see the `ErrorView` in action, we'll need to configure two options - `debug_errors: false` and `catch_errors: true` in `config/dev.exs`.
+> NOTE: In the development environment, this behavior will be overridden. Instead, we will get a really great debugging page. In order to see the `ErrorView` in action, we'll need to configure two options - `debug_errors: false` and `catch_errors: true` in `config/dev.exs`. The server must be restarted for the changes to be become effective.
 
 ```elixir
 config :hello_phoenix, HelloPhoenix.Endpoint,


### PR DESCRIPTION
It took me a little while to understand that `ErrorView` was not working because
my `dev.exs` did not get recompiled.
I therefore added a little note about this in the relevant section.