### PR TITLE
Update D_controllers.md

### DIFF
--- a/D_controllers.md
+++ b/D_controllers.md
@@ -386,7 +386,7 @@ Of course, we can pass data into our template as well. Let's change our action t
 
 ```elixir
 def index(conn, params) do
-  render conn, "index.text", message: params["message"]
+  render conn, :index, message: params["message"]
 end
 ```
 


### PR DESCRIPTION
The context is about using `_format` to select appropriate template, so we should use `:index` instead of `index.text`