### PR TITLE
Update the channels guide to match Phoenix 1.0.2

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -57,32 +57,29 @@ The default transport mechanism is via WebSockets which will fall back to LongPo
 Phoenix currently ships with its own JavaScript client. iOS and Android clients have been released with Phoenix 1.0.
 
 ## Tying it all together
-Let's tie all these ideas together by building a simple chat application. Let's start by mounting our socket in our endpoint and wiring up our channel routes.
+Let's tie all these ideas together by building a simple chat application. After [generating a new Phoenix application](http://www.phoenixframework.org/docs/up-and-running) we'll see that the endpoint is already set up for us in `lib/hello_phoenix/endpoint.ex`:
 
 ```elixir
-# lib/hello_phoenix/endpoint.ex
 defmodule HelloPhoenix.Endpoint do
-  use Phoenix.Endpoint
+  use Phoenix.Endpoint, otp_app: :hello_phoenix
 
   socket "/socket", HelloPhoenix.UserSocket
   ...
 end
+```
 
-# web/channels/user_socket.ex
+In `web/channels/user_socket.ex`, the `HelloPhoenix.UserSocket` we pointed to in our endpoint has already been created when we generated our application. We need to make sure messages get routed to the correct channel. To do that, we'll uncomment the "rooms:*" channel definition:
+
+```elixir
 defmodule HelloPhoenix.UserSocket do
   use Phoenix.Socket
 
+  ## Channels
   channel "rooms:*", HelloPhoenix.RoomChannel
-
-  transport :websocket, Phoenix.Transports.WebSocket
-
-  def connect(_params, socket), do: {:ok, socket}
-
-  def id(_socket), do: nil
-end
+  ...
 ```
 
-Now, whenever a client sends a message whose topic starts with `"rooms:"`, it will be routed to our RoomChannel. Next, we'll define a `RoomChannel` module to manage our chat room messages.
+Now, whenever a client sends a message whose topic starts with `"rooms:"`, it will be routed to our RoomChannel. Next, we'll define a `HelloPhoenix.RoomChannel` module to manage our chat room messages.
 
 ### Joining Channels
 
@@ -92,10 +89,10 @@ The first priority of your channels is to authorize clients to join a given topi
 defmodule HelloPhoenix.RoomChannel do
   use Phoenix.Channel
 
-  def join("rooms:lobby", auth_msg, socket) do
+  def join("rooms:lobby", _message, socket) do
     {:ok, socket}
   end
-  def join("rooms:" <> _private_room_id, _auth_msg, socket) do
+  def join("rooms:" <> _private_room_id, _params, _socket) do
     {:error, %{reason: "unauthorized"}}
   end
 end
@@ -103,22 +100,31 @@ end
 
 For our chat app, we'll allow anyone to join the `"rooms:lobby"` topic, but any other room will be considered private and special authorization, say from a database, will be required. We won't worry about private chat rooms for this exercise, but feel free to explore after we finish. To authorize the socket to join a topic, we return `{:ok, socket}` or `{:ok, reply, socket}`. To deny access, we return `{:error, reply}`. More information about authorization with tokens can be found in the [`Phoenix.Token` documentation](http://hexdocs.pm/phoenix/Phoenix.Token.html).
 
-With our channel in place, let’s head over to `web/static/js/app.js` and get the client and server talking.
+With our channel in place, let's get the client and server talking. There's some code in `web/static/js/socket.js` to connect to our socket and join our channel already, we just need to set our room name to "rooms:lobby".
 
 ```javascript
-import {Socket} from "deps/phoenix/web/static/js/phoenix"
-
-let socket = new Socket("/socket")
+...
 socket.connect()
-let chan = socket.channel("rooms:lobby", {})
-chan.join().receive("ok", chan => {
-  console.log("Welcome to Phoenix Chat!")
-})
+
+// Now that you are connected, you can join channels with a topic:
+let channel = socket.channel("rooms:lobby", {})
+channel.join()
+  .receive("ok", resp => { console.log("Joined successfully", resp) })
+  .receive("error", resp => { console.log("Unable to join", resp) })
+
+export default socket
 ```
 
-Save the file and your browser should auto refresh, thanks to the Phoenix live reloader. If everything worked, we should see "Welcome to Phoenix Chat!" in the browser's JavaScript console. Our client and server are now talking over a persistent connection. Now let's make it useful by enabling chat.
+After that, we need to make sure `web/static/socket.js` gets imported into our application javascript file. To do that, uncomment the last line in `web/static/js/app.js`.
 
-In `web/templates/page/index.html.eex`, add a container to hold our chat messages, and an input field to send them.
+```javascript
+...
+import socket from "./socket"
+```
+
+Save the file and your browser should auto refresh, thanks to the Phoenix live reloader. If everything worked, we should see "Joined successfully" in the browser's JavaScript console. Our client and server are now talking over a persistent connection. Now let's make it useful by enabling chat.
+
+In `web/templates/page/index.html.eex`, we'll replace the existing code with a container to hold our chat messages, and an input field to send them:
 
 ```html
 <div id="messages"></div>
@@ -132,61 +138,60 @@ We'll also add jQuery to our application layout in `web/templates/layout/app.htm
     <%= @inner %>
 
   </div> <!-- /container -->
-  <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
+  <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
   <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
 </body>
 ```
 
-Now let's add a couple of event listeners to `app.js`:
+Now let's add a couple of event listeners to `web/static/js/socket.js`:
 
 ```javascript
+...
+let channel           = socket.channel("rooms:lobby", {})
 let chatInput         = $("#chat-input")
 let messagesContainer = $("#messages")
 
-let socket = new Socket("/socket")
-socket.connect()
-let chan = socket.channel("rooms:lobby", {})
-
 chatInput.on("keypress", event => {
   if(event.keyCode === 13){
-    chan.push("new_msg", {body: chatInput.val()})
+    channel.push("new_msg", {body: chatInput.val()})
     chatInput.val("")
   }
 })
 
-chan.join().receive("ok", chan => {
-  console.log("Welcome to Phoenix Chat!")
-})
+channel.join()
+  .receive("ok", resp => { console.log("Joined successfully", resp) })
+  .receive("error", resp => { console.log("Unable to join", resp) })
+
+export default socket
 ```
 
 All we had to do is detect that enter was pressed and then `push` an event over the channel with the message body. We named the event "new_msg". With this in place, let's handle the other piece of a chat application where we listen for new messages and append them to our messages container.
 
-
 ```javascript
+...
+let channel           = socket.channel("rooms:lobby", {})
 let chatInput         = $("#chat-input")
 let messagesContainer = $("#messages")
 
-let socket = new Socket("/socket")
-socket.connect()
-let chan = socket.channel("rooms:lobby", {})
-
 chatInput.on("keypress", event => {
   if(event.keyCode === 13){
-    chan.push("new_msg", {body: chatInput.val()})
+    channel.push("new_msg", {body: chatInput.val()})
     chatInput.val("")
   }
 })
 
-chan.on("new_msg", payload => {
+channel.on("new_msg", payload => {
   messagesContainer.append(`<br/>[${Date()}] ${payload.body}`)
 })
 
-chan.join().receive("ok", chan => {
-  console.log("Welcome to Phoenix Chat!")
-})
+channel.join()
+  .receive("ok", resp => { console.log("Joined successfully", resp) })
+  .receive("error", resp => { console.log("Unable to join", resp) })
+
+export default socket
 ```
 
-We listen for the `"new_msg"` event using `chan.on`, and then append the message body to the DOM. Now let's handle the incoming and outgoing events on the server to complete the picture.
+We listen for the `"new_msg"` event using `channel.on`, and then append the message body to the DOM. Now let's handle the incoming and outgoing events on the server to complete the picture.
 
 ### Incoming Events
 We handle incoming events with `handle_in/3`. We can pattern match on the event names, like `"new_msg"`, and then grab the payload that the client passed over the channel. For our chat application, we simply need to notify all other `rooms:lobby` subscribers of the new message with `broadcast!/3`.
@@ -195,10 +200,10 @@ We handle incoming events with `handle_in/3`. We can pattern match on the event 
 defmodule HelloPhoenix.RoomChannel do
   use Phoenix.Channel
 
-  def join("rooms:lobby", auth_msg, socket) do
+  def join("rooms:lobby", _message, socket) do
     {:ok, socket}
   end
-  def join("rooms:" <> _private_room_id, _auth_msg, socket) do
+  def join("rooms:" <> _private_room_id, _params, _socket) do
     {:error, %{reason: "unauthorized"}}
   end
 
@@ -214,10 +219,10 @@ defmodule HelloPhoenix.RoomChannel do
 end
 ```
 
-`broadcast!/3` will notify all joined clients on this `socket`'s topic and invoke their `handle_out/3` callbacks. `handle_out/3` isn't required callback, but it allows us to customize and filter broadcasts before they reach each client. By default, `handle_out/3` is implemented for us and simply pushes the message on to the client, just like our definition. We included it here because hooking into outgoing events allows for powerful messages customization and filtering. Let's see how.
+`broadcast!/3` will notify all joined clients on this `socket`'s topic and invoke their `handle_out/3` callbacks. `handle_out/3` isn't a required callback, but it allows us to customize and filter broadcasts before they reach each client. By default, `handle_out/3` is implemented for us and simply pushes the message on to the client, just like our definition. We included it here because hooking into outgoing events allows for powerful message customization and filtering. Let's see how.
 
 #### Intercepting Outgoing Events
-We won't implement this for our application, but imagine our chat app allowed users to ignore messages about new users joining a room. We could implement that behavior like this where we explicitly tell phoenix which outgoing event we want to intercept, then defined a `handle_out/3` callback for those events. (Of course, this assumes that we have a `User` model with an `ignoring?/2` function, and that we pass a user in via the `assigns` map.)
+We won't implement this for our application, but imagine our chat app allowed users to ignore messages about new users joining a room. We could implement that behavior like this where we explicitly tell Phoenix which outgoing event we want to intercept and then define a `handle_out/3` callback for those events. (Of course, this assumes that we have a `User` model with an `ignoring?/2` function, and that we pass a user in via the `assigns` map.)
 
 ```elixir
 intercept ["user_joined"]
@@ -239,7 +244,7 @@ That's all there is to our basic chat app. Fire up multiple browser tabs and you
 Similar to connection structs, `%Plug.Conn{}`, it is possible to assign values to a channel socket. `Phoenix.Socket.assign/3` is conveniently imported into a channel module as `assign/3`:
 
 ```elixir
-  socket = assign(socket, :user, msg["user"])
+socket = assign(socket, :user, msg["user"])
 ```
 
 Sockets store assigned values as a map in `socket.assigns`.


### PR DESCRIPTION
Since some things have changed since the channels guide was written, I updated some of the code samples and a bit of the description so the guide matches Phoenix 1.0.2.

To make sure the code in the guide matches the current Phoenix version, I started out by generating a Phoenix 1.0.2 app named `HelloPhoenix` (like in the getting started guide) and worked from there. This means some small things changed, like the added `, otp_app: :hello_phoenix` in `lib/hello_phoenix/endpoint.ex

I tried to use as much of the generated code (like `lib/hello_phoenix/endpoint.ex`, `web/socket/user_socket.ex`, and `web/static/js/socket.js`) as possible. This means, for example, that all socket-related javascript code moved from `web/static/js/app.js` to `web/static/js/socket.js`, simply because a lot of the guide's code whas already generated there.
 
Although this is quite a big change, I tried to keep the changes as small as possible. I have fixed a typo or two along the way, though.

Oh, and here's a demo app of the guide's exact end result: https://github.com/jeffkreeftmeijer/phoenix_channels_example. It'll probably be useful to have this app around to help us update the guide when future versions of Phoenix are released.