### PR TITLE
Fixed a few typos and updated views guide

### DIFF
--- a/D_controllers.md
+++ b/D_controllers.md
@@ -420,7 +420,7 @@ For a list of valid content mime-types, please see the [mime.types](https://gith
 
 We can also set the HTTP status code of a response similarly to the way we set the content type. The `Plug.Conn` module, imported into all controllers, has a `put_status/2` function to do this.
 
-`put_status/2` takes `conn` as the first parameter and as the second parameter either an integer or a "friendly name" used as an atom for the status code we want to set. Here is the list of supported [friendly names](https://github.com/elixir-lang/plug/blob/master/lib/plug/conn/status.ex#L7-L63).
+`put_status/2` takes `conn` as the first parameter and as the second parameter either an integer or a "friendly name" used as an atom for the status code we want to set. Here is the list of supported [friendly names](https://github.com/elixir-lang/plug/blob/master/lib/plug/conn/status.ex#L7-L66).
 
 Let's change the status in our `PageController` `index` action.
 

--- a/E_views.md
+++ b/E_views.md
@@ -16,7 +16,7 @@ end
 
 That's simple enough. There's only one line, `use HelloPhoenix.Web, :view`. This line calls the `view/0` function we just saw above. Besides allowing us to change our template root, `view/0` exercises the `__using__` macro in the `Phoenix.View` module. It also handles any module imports or aliases our application's view modules might need.
 
-At the top of this file, we mentioned that views are a place to put functions for use in our templates. Let's experiment with that a little bit.
+At the top of this guide, we mentioned that views are a place to put functions for use in our templates. Let's experiment with that a little bit.
 
 Let's open up our application layout template, `templates/layout/app.html.eex`, and change this line,
 
@@ -55,17 +55,17 @@ Let's open up the `templates/page/index.html.eex` and locate this stanza.
 ```html
 <div class="jumbotron">
   <h2>Welcome to Phoenix!</h2>
-  <p class="lead">Most frameworks make you choose between speed and a productive environment. <a href="http://phoenixframework.org">Phoenix</a> and <a href="http://elixir-lang.org">Elixir</a> give you both.</p>
+  <p class="lead">A productive web framework that<br>does not compromise speed and maintainability.</p>
 </div>
 ```
 
-Then let's add a line with a link back to the same page. (The object is to see how path helpers respond in a template, not to add any functionality.)
+Then let's add a line with a link back to the same page. (The objective is to see how path helpers respond in a template, not to add any functionality.)
 
 ```html
 <div class="jumbotron">
   <h2>Welcome to Phoenix!</h2>
-  <p class="lead">Most frameworks make you choose between speed and a productive environment. <a href="http://phoenixframework.org">Phoenix</a> and <a href="http://elixir-lang.org">Elixir</a> give you both.</p>
-  <p><a href="<%= page_path @conn, :index %>">Link back to ourselves</a></p>
+  <p class="lead">A productive web framework that<br>does not compromise speed and maintainability.</p>
+  <p><a href="<%= page_path @conn, :index %>">Link back to this page</a></p>
 </div>
 ```
 


### PR DESCRIPTION
1 Fixed a few typos: were -> was
2 Updated the html in the Views guide to match the latest Phoenix version (1.0.3)
3 Updated a few words in the Views guide