### PR TITLE
Add links to iOS and Android channel clients

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -54,7 +54,7 @@ The default transport mechanism is via WebSockets which will fall back to LongPo
 
 - Client Libraries
 
-Phoenix currently ships with its own JavaScript client. iOS and Android clients have been released with Phoenix 1.0.
+Phoenix currently ships with its own JavaScript client. [iOS](https://github.com/davidstump/SwiftPhoenixClient), [Android](https://github.com/eoinsha/JavaPhoenixChannels), and [C#](https://github.com/livehelpnow/CSharpPhoenixClient) clients have been released with Phoenix 1.0.
 
 ## Tying it all together
 Let's tie all these ideas together by building a simple chat application. After [generating a new Phoenix application](http://www.phoenixframework.org/docs/up-and-running) we'll see that the endpoint is already set up for us in `lib/hello_phoenix/endpoint.ex`:


### PR DESCRIPTION
During ElixirConf, Chris McCord made mention of these clients to consume channels. This PR adds (AFAIK) the correct links to the most up-to-date/supported projects. I have no idea what the best C# client is, but [this blog post](http://www.phoenixframework.org/blog/phoenix-10-the-framework-for-the-modern-web-just-landed#beyond-the-browser) references it.


* contributed during the "How to contribute to Elixir and Phoenix" talk during ElixirConf