### PR TITLE
Added correct Heroku url

### DIFF
--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -117,7 +117,7 @@ url: [host: "example.com", port: 80],
 ... and replace it with this (don't forget to replace `mysterious-meadow-6277` with your application name):
 
 ```elixir
-url: [scheme: "https", host: "mysterious-meadow-6277.heroku.com", port: 443],
+url: [scheme: "https", host: "mysterious-meadow-6277.herokuapp.com", port: 443],
 force_ssl: [rewrite_on: [:x_forwarded_proto]],
 ```
 
@@ -136,7 +136,7 @@ use Mix.Config
 
 config :hello_phoenix, HelloPhoenix.Endpoint,
   http: [port: System.get_env("PORT")],
-  url: [scheme: "https", host: "mysterious-meadow-6277.heroku.com", port: 443],
+  url: [scheme: "https", host: "mysterious-meadow-6277.herokuapp.com", port: 443],
   force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/manifest.json",
   secret_key_base: System.get_env("SECRET_KEY_BASE")


### PR DESCRIPTION
All Heroku applications are hosted under `herokuapp` domain so each of them looks like `app-name.herokuapp.com`. [heroku.com](http://heroku.com/) is only for accessing a dashboard and no user apps are hosted as its subdomain.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/phoenixframework/phoenix_guides/387)
<!-- Reviewable:end -->
