### PR TITLE
Update link to Heroku sign up

### DIFF
--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -35,7 +35,7 @@ Heroku offers some great information on how it is using Git [here](https://devce
 
 ## Signing up for Heroku
 
-Signing up to Heroku is very simple, just head over to [https://signup.heroku.com/www-header](https://signup.heroku.com/www-header) and fill in the form.
+Signing up to Heroku is very simple, just head over to [https://signup.heroku.com/](https://signup.heroku.com/) and fill in the form.
 
 The Free plan will give us one web [dyno](https://devcenter.heroku.com/articles/dynos#dynos) and one worker dyno, as well as a PostgreSQL and Redis instance for free.
 


### PR DESCRIPTION
Though `/www-header` works, it's actually an artifact of legacy Heroku code. This update makes the link more clear by removing the path.

source: I work on the Heroku www & signup apps.