### PR TITLE
minor updates in Ecto Models guide and Testing Introduction guide

### DIFF
--- a/E_views.md
+++ b/E_views.md
@@ -72,7 +72,7 @@ Then let's add a line with a link back to the same page. (The objective is to se
 Now we can reload the page and view source to see what we have.
 
 ```html
-<a href="/">Link back to ourselves</a>
+<a href="/">Link back to this page</a>
 ```
 
 Great, `page_path/2` evaluated to `/` as we would expect, and we didn't need to qualify it with `HelloPhoenix.View`.

--- a/H_ecto_models.md
+++ b/H_ecto_models.md
@@ -548,7 +548,7 @@ Handling individual tables is great, but if we want to build a modern web applic
 
 `Schema.belongs_to/3` declares a one to one relationship between parent and children models. In our video site example, an uploaded video belongs to its user.
 
-`Schema.has_one/3` declares a one to one relationship. Note that has_one is just like has_many except instead of returning a collection of model structs, we get just one model struct. Continuing with the video-sharing example, while a user might have many uploaded videos, the user might only have one featured video.
+`Schema.has_one/3` declares a one to one relationship. Note that has_one is just like has_many except instead of returning a collection of model structs, it returns only one model struct. Continuing with the video-sharing example, while a user might have many uploaded videos, the user might only have one featured video.
 
 Here's how we would declare a `has_many` relationship in `web/models/user.ex`:
 ```elixir
@@ -604,11 +604,11 @@ defmodule HelloPhoenix.UserController do
 . . .
 end
 ```
-Because we declared a relationship in `HelloPhoenix.User`, `%User{}` will now contain a videos property which starts out as an unloaded relationship. In order to properly display it in `render`, we'll need to tell Ecto to preload the field. Note that `Repo.preload/2` is smart enough to work on just one model or collection of them.
+Because we declared a relationship in `HelloPhoenix.User`, `%User{}` will now contain a videos property which starts out as an unloaded relationship. In order to properly display it in `render`, we'll need to tell Ecto to preload the field. Note that `Repo.preload/2` is smart enough to work on just one model or a collection of them.
 
 ### Working with Callback Hooks
 
-Continuing with our video sharing app example, many web applications require moderation for user submitted content. Our Video model has an `approved_at` field to signify that a moderator has approved the video. The question is, what happens if the user edits the video? Ideally, we'd like to be able to "null out" a video's `approved_at` field when this happens. Fortunately, Ecto provides us with a handful of life-cycle callbacks to achieve this.
+Continuing with our video sharing app example, it requires moderation for user submitted content just like many other web applications. Our Video model has an `approved_at` field to signify that a moderator has approved the video. The question is, what happens if the user edits the video? Ideally, we'd like to be able to "null out" a video's `approved_at` field when this happens. Fortunately, Ecto provides us with a handful of life-cycle callbacks to achieve this.
 
 We will instruct Ecto to use the `before_update` hook in `web/models/video.ex` like so:
 

--- a/testing/A_introduction.md
+++ b/testing/A_introduction.md
@@ -445,7 +445,7 @@ Randomized with seed 401472
 
 We've seen what Phoenix gives us with a newly generated app. Now let's see what happens when we generate a new HTML resource.
 
-Let's borrow the resource we created in the [Mix Tasks Guide](http://www.phoenixframework.org/docs/ecto-models).
+Let's borrow the `users` resource we created in the [Ecto Models Guide](http://www.phoenixframework.org/docs/ecto-models).
 
 At the root of our new application, let's run the `mix phoenix.gen.html` task with the following options.
 


### PR DESCRIPTION
1 In Ecto Models guide, for the second sentence on line 551 of Ecto Models guide, since the sentence has `has_one` as the subject, it feels more nature for the except clause to start with `it`

2 In Ecto Models guide, for the first sentence under subtitle `Working with Callback Hooks`, the main clause `many web applications require moderation for user submitted content` feels unrelated to the part before it. So I tried to edit it. But other editing suggestions are most welcome for this.

3 In Testing Introduction guide, fixed the text for the link to Ecto Models guide

Please let me know what do you think @lancehalvorsen . Thanks!