### PR TITLE
Fix the code block got included in quote

### DIFF
--- a/testing/A_introduction.md
+++ b/testing/A_introduction.md
@@ -223,6 +223,7 @@ Randomized with seed 125659
 ```
 
 > Note: ExUnit tells us exactly which tags it is including and excluding for each test run. If we look back to the previous section on running tests, we'll see that line numbers specified for individual tests are actually treated as tags.
+
 ```console
 $ mix test test/views/error_view_test.exs:12
 Including tags: [line: "12"]


### PR DESCRIPTION
Very small issue, , the code block got included in the `<` quote,  which also affects normal text rendering at the next line. 

before:
![before](https://cloud.githubusercontent.com/assets/1011678/10416844/42b45db2-701f-11e5-856e-c0a18d46bfc2.png)


after:
![after](https://cloud.githubusercontent.com/assets/1011678/10416845/52b1175a-701f-11e5-8f74-bdb3d7eba87b.png)
