### PR TITLE
Update SSL Guide Relative Path Usage

### DIFF
--- a/bonus_guides/P_using_ssl.md
+++ b/bonus_guides/P_using_ssl.md
@@ -1,6 +1,6 @@
 To prepare an application to serve requests over SSL, we need to add a little bit of configuration and two environment variables. In order for SSL to actually work, we'll need a key file and certificate file from a certificate authority. The environment variables that we'll need are paths to those two files.
 
-The configuration consists of a new `https:` key for our endpoint whose value is a keyword list of port, path to the key file, and path to the cert (pem) file. If we add the `otp_app:` key whose value is the name of our application, we can put the key and certificate files in the `priv` directory of our application, and Plug will look for them there. The values of our environment variables should then be relative paths.
+The configuration consists of a new `https:` key for our endpoint whose value is a keyword list of port, path to the key file, and path to the cert (pem) file. If we add the `otp_app:` key whose value is the name of our application, Plug will begin to look for them at the root of our application. We can then put those files in our `priv` directory and set the paths to `priv/our_keyfile.key` and `priv/our_cert.crt`.
 
 Here's an example configuration from `config/prod.exs`.
 


### PR DESCRIPTION
Relative paths begin at the root of the project, not `priv/`, when specifying otp_app key.

closes #395