### PR TITLE
fix missing comma in email config

### DIFF
--- a/bonus_guides/I_sending_email.md
+++ b/bonus_guides/I_sending_email.md
@@ -32,7 +32,7 @@ One way is quick, but it requires us to set environment variables for our mailgu
 
 ```elixir
 config :hello_phoenix,
-       mailgun_domain: System.get_env("MAILGUN_DOMAIN")
+       mailgun_domain: System.get_env("MAILGUN_DOMAIN"),
        mailgun_key: System.get_env("MAILGUN_API_KEY")
 ```
 


### PR DESCRIPTION
The missing comma creates the following error:
```
** (Mix.Config.LoadError) could not load config config/config.exs
    ** (SyntaxError) config/config.exs:29: syntax error before: mailgun_key
```
This pull request addresses a minor problem in the "sending email" documentation that can be a hurdle to newer people to phoenix as it is subtle and completely breaks a persons phoenix app.