### PR TITLE
fix URL of elixir guides

### DIFF
--- a/bonus_guides/V_learning_elixir.md
+++ b/bonus_guides/V_learning_elixir.md
@@ -1,7 +1,7 @@
 Here is a selected list of resources to help with learning Elixir and Erlang.
 
 ## Elixir
-- [Elixir Guides](http://elixir-lang.org/getting_started/1.html)
+- [Elixir Guides](http://elixir-lang.org/getting-started/introduction.html)
 - [Official Documentation](http://elixir-lang.org/docs/stable/elixir)
 
 ##### Books

--- a/introduction/A_overview.md
+++ b/introduction/A_overview.md
@@ -2,7 +2,7 @@ Phoenix is a web development framework written in Elixir which implements the se
 
 Phoenix provides the best of both worlds - high developer productivity _and_ high application performance. It also has some interesting new twists like channels for implementing realtime features and pre-compiled templates for blazing speed.
 
-If you are already familiar with Elixir, great! If not, there are a number of places to learn. The [Elixir guides](http://elixir-lang.org/getting_started/1.html) are a great place to start. We also have a list of helpful resources in the [Learning Elixir and Erlang Guide](http://www.phoenixframework.org/docs/learning-elixir-and-erlang).
+If you are already familiar with Elixir, great! If not, there are a number of places to learn. The [Elixir guides](http://elixir-lang.org/getting-started/introduction.html) are a great place to start. We also have a list of helpful resources in the [Learning Elixir and Erlang Guide](http://www.phoenixframework.org/docs/learning-elixir-and-erlang).
 
 The aim of this introductory guide is to present a brief, high-level overview of Phoenix, the parts that make it up, and the layers underneath that support it.
 


### PR DESCRIPTION
I think now that it http://elixir-lang.org/getting-started/introduction.html  is correct URL