### PR TITLE
Update broken and 301'-ing links

### DIFF
--- a/bonus_guides/V_learning_elixir.md
+++ b/bonus_guides/V_learning_elixir.md
@@ -5,14 +5,14 @@ Here is a selected list of resources to help with learning Elixir and Erlang.
 - [Official Documentation](http://elixir-lang.org/docs/stable/elixir)
 
 ##### Books
-- [Programming Elixir](http://pragprog.com/book/elixir/programming-elixir), Dave Thomas
-- [Elixir in Action](http://www.manning.com/juric/), Saša Jurić
+- [Programming Elixir](https://pragprog.com/book/elixir/programming-elixir), Dave Thomas
+- [Elixir in Action](https://www.manning.com/juric/), Saša Jurić
 - [Introducing Elixir](http://shop.oreilly.com/product/0636920030584.do), Simon St. Laurent, J. David Eisenberg
 - [Metaprogramming Elixir](https://pragprog.com/book/cmelixir/metaprogramming-elixir), Chris McCord
-- [The Little Elixir & OTP Guidebook](http://www.manning.com/tanweihao/), Benjamin Tan Wei Hao
+- [The Little Elixir & OTP Guidebook](https://www.manning.com/tanweihao/), Benjamin Tan Wei Hao
 
 ##### Videos
-- [All Aboard The Elixir Express](http://www.confreaks.com/videos/3488-railsconf-workshop-all-aboard-the-elixir-expresse), Chris McCord
+- [All Aboard The Elixir Express](http://www.confreaks.tv/videos/railsconf2014-workshop-all-aboard-the-elixir-express), Chris McCord
 
 ##### The Erlangelist: Understanding Elixir Macros, by Saša Jurić
   - [Part 1](http://www.theerlangelist.com/2014/06/understanding-elixir-macros-part-1.html)
@@ -25,10 +25,10 @@ Here is a selected list of resources to help with learning Elixir and Erlang.
 - [Erlang User Guide](http://www.erlang.org/doc/getting_started/users_guide.html)
 
 ##### Books
-- [Programming Erlang](http://pragprog.com/book/jaerlang2/programming-erlang), 2nd Edition, Joe Armstrong
+- [Programming Erlang](https://pragprog.com/book/jaerlang2/programming-erlang), 2nd Edition, Joe Armstrong
 - [Introducing Erlang](http://shop.oreilly.com/product/0636920025818.do), Simon St. Laurent
-- [Learn You Some Erlang for Great Good!](http://www.nostarch.com/erlang), Fred Hébert
-- [Erlang and OTP in Action](http://www.manning.com/logan/), Martin Logan, Eric Merritt, and Richard Carlsson
+- [Learn You Some Erlang for Great Good!](https://www.nostarch.com/erlang), Fred Hébert
+- [Erlang and OTP in Action](https://www.manning.com/logan/), Martin Logan, Eric Merritt, and Richard Carlsson
 - [Erlang Programming](http://shop.oreilly.com/product/9780596518189.do), Francesco Cesarini and Simon Thompson
 - [Designing for Scalability with Erlang/OTP](http://shop.oreilly.com/product/0636920024149.do), Francesco Cesarini, Steve Vinoski
 - [Erlang in Anger](http://www.erlang-in-anger.com/), Fred Hébert

--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -153,7 +153,7 @@ config :hello_phoenix, HelloPhoenix.Repo,
 
 ## Creating Environment Variables in Heroku
 
-The `DATABASE_URL` config var is automatically created by Heroku when we add the [Heroku Postgres add-on](https://addons.heroku.com/heroku-postgresql).
+The `DATABASE_URL` config var is automatically created by Heroku when we add the [Heroku Postgres add-on](https://elements.heroku.com/addons/heroku-postgresql).
 
 We still have to create the `SECRET_KEY_BASE` config based on a random string. First, use `mix phoenix.gen.secret` to get a new secret:
 

--- a/deployment/I_exrm_releases.md
+++ b/deployment/I_exrm_releases.md
@@ -61,7 +61,7 @@ Now we need to update our `mix.exs` file to have all production dependencies lis
   end
 ```
 
-Doing this helps us overcome one of [exrm's common issues](https://github.com/bitwalker/exrm#common-issues) by helping exrm know about all our dependencies so that it can properly bundle them into our release. Without this, our application will probably alert us about missing modules or a failure to start a child application when we go to run our release.
+Doing this helps us overcome one of [exrm's common issues](https://hexdocs.pm/exrm/extra-common-issues.html) by helping exrm know about all our dependencies so that it can properly bundle them into our release. Without this, our application will probably alert us about missing modules or a failure to start a child application when we go to run our release.
 
 Even if we list all of our dependencies, our application may still fail. Typically, this happens because one of our dependencies does not properly list its own dependencies. A quick fix for this is to include the missing dependency or dependencies in our list of applications. If this happens to you, and you feel like helping the community, you can create an issue or a pull request to that project's repo.
 
@@ -153,7 +153,7 @@ There are a couple of interesting things to note here.
 
 - Exrm has created a `rel` directory at the root of our application where it has written everything related to this release.
 
-Exrm uses a set of default configuration options when building our release that will work for most applications. If we need more advanced configuration options, we can checkout [exrm's configuration section](https://github.com/bitwalker/exrm#configuration) for more detailed information.
+Exrm uses a set of default configuration options when building our release that will work for most applications. If we need more advanced configuration options, we can checkout [exrm's configuration section](https://hexdocs.pm/exrm/extra-release-configuration.html#content) for more detailed information.
 
 If we make a mistake, or if something doesn't go quite right, we can run `mix release.clean`, which will delete the release for the current application version number. If we add the `--implode` flag, exrm will remove _all_ releases for all versions of our application. These will be permanently removed unless they are under version control. Obviously, this is a destructive operation, and exrm will prompt us to make sure we want to continue.
 
@@ -446,7 +446,7 @@ upstream hello_phoenix {
     server 127.0.0.1:8888;
 }
 # The following map statement is required
-# if you plan to support channels. See http://nginx.com/blog/websocket-nginx/
+# if you plan to support channels. See https://www.nginx.com/blog/websocket-nginx/
 map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
@@ -472,6 +472,6 @@ server{
 }
 ```
 
-Like our `upstart` script, this nginx config is basic. Look to the [nginx wiki](http://wiki.nginx.org/Main) for steps to configure any more involved features. Restart nginx with `sudo service nginx restart` to load our new config.
+Like our `upstart` script, this nginx config is basic. Look to the [nginx wiki](https://www.nginx.com/resources/wiki/) for steps to configure any more involved features. Restart nginx with `sudo service nginx restart` to load our new config.
 
 At this point, we should be able to see our application if we visit `http://hostname.com/` if everything has been successful up to this point.


### PR DESCRIPTION
After seeing #408, I used [this little script](https://gist.github.com/jeffkreeftmeijer/5e36a0cfa7e2c735386e) to check the rest of the urls in the guides. 

* ~~Link to the sign up page from the email guide, and replace occurences
  of "mailgun.com" with "Mailgun".~~ moved to https://github.com/phoenixframework/phoenix_guides/pull/411
* Use https links to pragprog.om, manning.com and nostarch.com
* Update links to https://www.nginx.com
* Use confreaks.tv instead of .com
* Use elements.heroku.com/addons instead of addons.heroku.com
* Switch to hexdocs.pm for exrm's documentation