### PR TITLE
Make heroku deploy instructions compatible with latest Elixir/Erlang

### DIFF
--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -278,6 +278,44 @@ $ heroku run mix ecto.migrate
 
 And that's it!
 
+## Seeing errors?
+
+Sometimes our Phoenix app can be incompatible with the versions of Erlang and Elixir that the buildpack provides by default.
+
+```
+...
+remote:  !     Push rejected, Internal error, please try again
+remote:
+remote: Verifying deploy....
+remote:
+remote: !	Push rejected to mysterious-meadow-6277.
+remote:
+To https://git.heroku.com/mysterious-meadow-6277.git
+ ! [remote rejected] master -> master (pre-receive hook declined)
+error: failed to push some refs to 'https://git.heroku.com/mysterious-meadow-6277.git'
+```
+
+We can override these default by adding `elixir_buildpack.config` to our project:
+
+```
+erlang_version=18.0
+elixir_version=1.0.5
+```
+
+And then deploy again:
+
+```
+$ git add elixir_buildpack.config
+$ git commit -m "Explicitly specify Erlang and Elixir versions for Heroku"
+$ git push heroku master
+...
+remote: Verifying deploy... done.
+To https://git.heroku.com/mysterious-meadow-6277.git
+ * [new branch]      master -> master
+ ```
+ 
+And that's really it!
+
 ## Useful Heroku Commands
 
 We can look at the logs of our application by running the following command in our project directory:


### PR DESCRIPTION
I've just tried to follow the existing instructions and bumped into weird error

```
remote:  !     Push rejected, Internal error, please try again
```

Not the most clear error message.

As it turned out, I needed to specify the exact versions of Erlang and Elixir in the buildpack config file. After doing this, the deployment went smoothly.

English is not my native language, so whoever is going to review it - please feel free to change wording, rephrase sentences, etc.

Maybe it's better to update the buildpack itself rather than change the documentation - I'm not sure. Let's discuss it there.