### PR TITLE
Update the templates guide

### DIFF
--- a/F_templates.md
+++ b/F_templates.md
@@ -1,4 +1,4 @@
-Templates are what they sound like they should be - files into which we pass data to form complete HTTP responses. For a web application these responses would typically be full HTML documents. For an API, they would most often be JSON or possibly XML. The majority of the code in template files is often markup, but there will also be sections of Elixir code for Phoenix to compile and evaluate. The fact that Phoenix templates are pre-compiled makes them extremely fast.
+Templates are what they sound like they should be: files into which we pass data to form complete HTTP responses. For a web application these responses would typically be full HTML documents. For an API, they would most often be JSON or possibly XML. The majority of the code in template files is often markup, but there will also be sections of Elixir code for Phoenix to compile and evaluate. The fact that Phoenix templates are pre-compiled makes them extremely fast.
 
 EEx is the default template system in Phoenix, and it is quite similar to ERB in Ruby. It is actually part of Elixir itself, and Phoenix uses EEx templates to create files like the router and the main application view while generating a new application.
 
@@ -10,53 +10,67 @@ We've already seen several ways in which templates are used, notably in the [Add
 
 ##### web.ex
 
-Phoenix generates `web/web.ex` file that serves as place to group commons imports and aliases. All declarations here within the `view` block apply to all your templates.
+Phoenix generates a `web/web.ex` file that serves as place to group commons imports and aliases. All declarations here within the `view` block apply to all your templates.
 
 Let's make some additions to our application so we can experiment a little.
 
 First, let's define a new route in `web/router.ex`.
 
 ```elixir
-scope "/", HelloPhoenix do
-  pipe_through :browser # Use the default browser stack
+defmodule HelloPhoenix.Router do
+  ...
 
-  get "/", PageController, :index
-  get "/test", PageController, :test
+  scope "/", HelloPhoenix do
+    pipe_through :browser # Use the default browser stack
+
+    get "/", PageController, :index
+    get "/test", PageController, :test
+  end
+
+  # Other scopes may use custom stacks.
+  # scope "/api", HelloPhoenix do
+  #   pipe_through :api
+  # end
 end
 ```
 
 Now, let's define the controller action we specified in the route. We'll add a `test/2` action in the `web/controllers/page_controller.ex` file.
 
 ```elixir
-def test(conn, _params) do
-  render conn, "test.html"
-end
+defmodule HelloPhoenix.PageController do
+  ...
 
+  def test(conn, _params) do
+    render conn, "test.html"
+  end
+end
 ```
+
 We're going to create a function that tells us which controller and action are handling our request.
 
-To do that, we need to import the `action_name/1` and `controller_module/1` functions from `Phoenix.Controller` in the main view.
+To do that, we need to import the `action_name/1` and `controller_module/1` functions from `Phoenix.Controller` in `web/web.ex`.
 
 ```elixir
-defmodule HelloPhoenix.Web do
-  ...
   def view do
     quote do
       use Phoenix.View, root: "web/templates"
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1,
-                                        action_name: 1, controller_module: 1] # Add these as imported functions
-  ...
+                                        action_name: 1, controller_module: 1]
+
+      ...
+    end
+  end
 ```
 
 Next, let's define a `handler_info/1` function at the bottom of the `web/views/page_view.ex` which makes use of the `controller_module/1` and `action_name/1` functions we just imported. We'll also define a `connection_keys/1` function that we'll use in a moment.
 
 ```elixir
-. . .
 defmodule HelloPhoenix.PageView do
-  ...
-  def handler_info(conn) do
+  use HelloPhoenix.Web, :view
+
+    def handler_info(conn) do
     "Request Handled By: #{controller_module conn}.#{action_name conn}"
   end
 
@@ -66,16 +80,14 @@ defmodule HelloPhoenix.PageView do
     |> Map.keys()
   end
 end
-
 ```
 
 We have a route. We created a new controller action. We have made modifications to the main application view. Now all we need is a new template to display the string we get from `handler_info/1`. Let's create a new one at `web/templates/page/test.html.eex`.
 
-```elixir
+```html
 <div class="jumbotron">
   <p><%= handler_info @conn %></p>
 </div>
-
 ```
 
 Notice that `@conn` is available to us in the template for free via the `assigns` map.
@@ -83,7 +95,6 @@ Notice that `@conn` is available to us in the template for free via the `assigns
 If we visit [localhost:4000/test](http://localhost:4000/test), we will see that our page is brought to us by `Elixir.HelloPhoenix.PageController.test`.
 
 We can define functions in any individual view in `web/views`. Functions defined in an individual view will only be available to templates which that view renders. For example, functions like our `handler_info` above, will only be available to templates in `web/templates/page`.
-
 
 ##### Displaying Lists
 
@@ -95,7 +106,7 @@ Now that we have a function, visible to our template, that returns a list of key
 
 We can add a header and a list comprehension like this.
 
-```elixir
+```html
 <div class="jumbotron">
   <p><%= handler_info @conn %></p>
 
@@ -106,6 +117,7 @@ We can add a header and a list comprehension like this.
   <% end %>
 </div>
 ```
+
 We use the list of keys returned by the `connection_keys` function as the source list to iterate over. Note that we need the `=` in both `<%=` - one for the top line of the list comprehension and the other to display the key. Without them, nothing would actually be displayed.
 
 When we visit [localhost:4000/test](http://localhost:4000/test) again, we see all the keys displayed.
@@ -114,7 +126,7 @@ When we visit [localhost:4000/test](http://localhost:4000/test) again, we see al
 
 In our list comprehension example above, the part that actually displays the values is quite simple.
 
-```elixir
+```html
 <p><%= key %></p>
 ```
 We are probably fine with leaving this in place. Quite often, however, this display code is somewhat more complex, and putting it in the middle of a list comprehension makes our templates harder to read.
@@ -123,17 +135,24 @@ The simple solution is to use another template! Templates are just function call
 
 Let's turn this display snippet into its own template. Let's create a new template file at `web/templates/page/key.html.eex`, like this.
 
-```elixir
+```html
 <p><%= @key %></p>
 ```
+
 We need to change `key` to `@key` here because this is a new template, not part of a list comprehension. The way we pass data into a template is by the `assigns` map, and the way we get the values out of the `assigns` map is by referencing the keys with a preceding `@`.
 
 Now that we have a template, we simply render it within our list comprehension in the `test.html.eex` template.
 
-```elixir
-<%= for key <- connection_keys @conn do %>
-  <%= render "key.html", key: key %>
-<% end %>
+```html
+<div class="jumbotron">
+  <p><%= handler_info @conn %></p>
+
+  <h3>Keys for the conn Struct</h3>
+
+  <%= for key <- connection_keys @conn do %>
+    <%= render "key.html", key: key %>
+  <% end %>
+</div>
 ```
 
 Let's take a look at [localhost:4000/test](http://localhost:4000/test) again. The page should look exactly as it did before.
@@ -146,10 +165,14 @@ Let's move our template into a shared view.
 
 `key.html.eex` is currently rendered by the `HelloPhoenix.PageView` module, but we use a render call which assumes that the current view model is what we want to render with. We could make that explicit, and re-write it like this:
 
-```elixir
-<%= for key <- connection_keys @conn do %>
-  <%= render HelloPhoenix.PageView, "key.html", key: key %>
-<% end %>
+```html
+<div class="jumbotron">
+  ...
+
+  <%= for key <- connection_keys @conn do %>
+    <%= render HelloPhoenix.PageView, "key.html", key: key %>
+  <% end %>
+</div>
 ```
 
 Since we want this to live in a new `web/templates/shared` directory, we need a new individual view to render templates in that directory, `web/views/shared_view.ex`.


### PR DESCRIPTION
I've updated the templates testing guide to make sure the code blocks are clear and accurate, fix some typos and do some styling fixes and in line with the rest of the guides:

* Change "…what they […] should be - files…" to "…what they […] should
be: files…"
* "…generates `web/web.ex` file…" => "…generates a `web/web.ex file…"
* Explicitly state that "the main view" is in `web/web.ex`
* Add module lines around code blocks (like `defmodule HelloPhoenix.PageController do`
  and `end`) to add context and indent accordingly.
* Display the comment at the end of web/router.ex to add context and not have to break the file up twice.
* Use `html` instead of `elixir` as the info string for template code blocks.
* Remove trailing newlines in code blocks
* Add missing newlines after code blocks
* Remove a double newline before the “Displaying Lists” heading

Here's the example app I used: https://github.com/jeffkreeftmeijer/phoenix_guides-templates-example