### PR TITLE
Don't explain how to change the template root directory

### DIFF
--- a/F_templates.md
+++ b/F_templates.md
@@ -2,7 +2,7 @@ Templates are what they sound like they should be - files into which we pass dat
 
 EEx is the default template system in Phoenix, and it is quite similar to ERB in Ruby. It is actually part of Elixir itself, and Phoenix uses EEx templates to create files like the router and the main application view while generating a new application.
 
-As we learned in the [View Guide](http://www.phoenixframework.org/docs/views), by default, templates live in the `web/templates` directory, organized into directories named after a view. Each directory has its own view module to render the templates in it. We can change the template root directory by specifying a new one in the `root: "web/templates"` declaration in the main application view.
+As we learned in the [View Guide](http://www.phoenixframework.org/docs/views), by default, templates live in the `web/templates` directory, organized into directories named after a view. Each directory has its own view module to render the templates in it.
 
 ### Examples
 


### PR DESCRIPTION
While interesting to know, explaining how to change the template root directory is out of the scope of the templates guide, as changing the template root is something you should probably only do when you're more familiar with the framework. Also, putting it at the start of the guide like this is confusing, as it's not completely clear if the reader should do anything with the template root directory or not. It might be
a good idea to move this elsewhere.

I'm opening a separate pull request for this instead of throwing it in with #422 to have some room for discussion wether this should be removed or not.