### PR TITLE
Minor fixes to the templates guide

### DIFF
--- a/F_templates.md
+++ b/F_templates.md
@@ -183,9 +183,9 @@ defmodule HelloPhoenix.SharedView do
 end
 ```
 
-Now we can move `key.html.eex` from the `web/templates/page` directory into the `web/templates/shared` directory. Once that happens, we can change the render call to use the new `HelloPhoenix.SharedView`.
+Now we can move `key.html.eex` from the `web/templates/page` directory into the `web/templates/shared` directory. Once that happens, we can change the render call in `web/templates/page/test.html.eex` to use the new `HelloPhoenix.SharedView`.
 
-```elixir
+```html
 <%= for key <- connection_keys @conn do %>
   <%= render HelloPhoenix.SharedView, "key.html", key: key %>
 <% end %>


### PR DESCRIPTION
This seems to have slipped through when working on #422.

* Mention the filename (`web/templates/page/test.html.eex`) in the
  paragraph above the last code block, as moving one file and editing
  another might be confusing
* Use `html` instead of `elixir` as the info string for the last code
  block