### PR TITLE
Clarifying a hiccup in the guide when using --no-brunch

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -100,9 +100,14 @@ end
 
 For our chat app, we'll allow anyone to join the `"rooms:lobby"` topic, but any other room will be considered private and special authorization, say from a database, will be required. We won't worry about private chat rooms for this exercise, but feel free to explore after we finish. To authorize the socket to join a topic, we return `{:ok, socket}` or `{:ok, reply, socket}`. To deny access, we return `{:error, reply}`. More information about authorization with tokens can be found in the [`Phoenix.Token` documentation](http://hexdocs.pm/phoenix/Phoenix.Token.html).
 
-With our channel in place, let's get the client and server talking. There's some code in `web/static/js/socket.js` to connect to our socket and join our channel already, we just need to set our room name to "rooms:lobby".
+With our channel in place, let's get the client and server talking.
+
+Phoenix projects come with [brunch.io] built in, unless disabled with the `--no-brunch` option when you run `mix phoenix.new`.
+
+If you are using brunch, there's some code in `web/static/js/socket.js` that defines a simple client utilizing the phoenix javascript library, which is used to connect to our socket and join our channel, we just need to set our room name to "rooms:lobby" in that file.
 
 ```javascript
+//web/static/js/socket.js
 ...
 socket.connect()
 
@@ -138,7 +143,7 @@ We'll also add jQuery to our application layout in `web/templates/layout/app.htm
     <%= @inner %>
 
   </div> <!-- /container -->
-  <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
+  <script src="//code.jquery.com/jquery-1.11.9.min.js"></script>
   <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
 </body>
 ```

--- a/G_channels.md
+++ b/G_channels.md
@@ -102,12 +102,14 @@ For our chat app, we'll allow anyone to join the `"rooms:lobby"` topic, but any 
 
 With our channel in place, let's get the client and server talking.
 
-Phoenix projects come with [brunch.io] built in, unless disabled with the `--no-brunch` option when you run `mix phoenix.new`.
+Phoenix projects come with [Brunch](http://www.phoenixframework.org/docs/static-assets) built in, unless disabled with the `--no-brunch` option when you run `mix phoenix.new`.
 
-If you are using brunch, there's some code in `web/static/js/socket.js` that defines a simple client utilizing the phoenix javascript library, which is used to connect to our socket and join our channel, we just need to set our room name to "rooms:lobby" in that file.
+If you are using brunch, there's some code in `web/static/js/socket.js` that defines a simple client based on the socket implementation that ships with Phoenix.
+
+We can use that library to connect to our socket and join our channel, we just need to set our room name to "rooms:lobby" in that file.
 
 ```javascript
-//web/static/js/socket.js
+// web/static/js/socket.js
 ...
 socket.connect()
 


### PR DESCRIPTION
There's an implied notion in the channel guide that you've created a test project with brunch.  When I wasn't able to find the related files the guide spoke of, I didn't have the context that they only came along with the brunch-enabled generator.

This adds a straightforward sentence to the guide that explains that these files are present only in the 'standard' generator, so users have an inkling on why they might not have the same files.  True story. 

Also, bumped jQuery to use the latest  < 1.x version (as of now, 1.11.9)