### PR TITLE
Update the "Up and running" guide

### DIFF
--- a/A_up_and_running.md
+++ b/A_up_and_running.md
@@ -18,12 +18,18 @@ $ mix phoenix.new hello_phoenix
 
 > A note about [Brunch.io](http://brunch.io/) before we begin: Phoenix will use Brunch.io for asset management by default. Brunch.io's dependencies are installed via the node package manager, not mix. Phoenix will prompt us to install them at the end of the `mix phoenix.new` task. If we say "no" at that point, and if we don't install those dependencies later with `npm install`, our application will raise errors when we try to start it, and our assets may not load properly. If we don't want to use Brunch.io at all, we can simply pass `--no-brunch` to `mix phoenix.new`.
 
-Now that we're ready, let's call `phoenix.new` with a relative path.
+Now that we're ready, let's run `mix phoenix.new` with a relative path.
 
 ```console
-$ mix phoenix.new hello_phoenix
-* creating hello_phoenix/README.md
-. . .
+mix phoenix.new hello_phoenix
+* creating hello_phoenix/config/config.exs
+* creating hello_phoenix/config/dev.exs
+* creating hello_phoenix/config/prod.exs
+...
+* creating hello_phoenix/web/views/layout_view.ex
+* creating hello_phoenix/web/views/page_view.ex
+
+Fetch and install dependencies? [Yn]
 ```
 
 Phoenix generates the directory structure and all the files we will need for our application. When it's done, it will ask us if we want it to install our dependencies for us. Let's say yes to that.
@@ -32,11 +38,7 @@ Phoenix generates the directory structure and all the files we will need for our
 Fetch and install dependencies? [Yn] y
 * running npm install && node node_modules/brunch/bin/brunch build
 * running mix deps.get
-```
 
-Once our dependencies are installed, the task will prompt us to change into our project directory and start our application.
-
-```console
 We are all set! Run your Phoenix application:
 
     $ cd hello_phoenix
@@ -48,14 +50,27 @@ You can also run your app inside IEx (Interactive Elixir) as:
     $ iex -S mix phoenix.server
 ```
 
+Once our dependencies are installed, the task will prompt us to change into our project directory and start our application.
+
 Phoenix assumes that our PostgreSQL database will have a `postgres` user account with the correct permissions and a password of "postgres". If that isn't the case, please see the instructions for the [ecto.create](http://www.phoenixframework.org/docs/mix-tasks#section--ecto-create-) mix task.
 
-Ok, let's give it a try.
+Ok, let's give it a try. First, we'll `cd` into the `hello_phoenix/` directory we've just created:
+
+    $ cd hello_phoenix
+
+Now we'll create our database:
+
+```
+$ mix ecto.create
+The database for HelloPhoenix.Repo has been created.
+```
+
+And finally, we'll start the Phoenix server:
 
 ```console
-$ cd hello_phoenix
-$ mix ecto.create
 $ mix phoenix.server
+[info] Running HelloPhoenix.Endpoint with Cowboy on http://localhost:4000
+23 Nov 05:25:14 - info: compiled 5 files into 2 files, copied 3 in 1724ms
 ```
 
 > Note: if this is the first time you are running this command, Phoenix may also ask to install Rebar. Go ahead with the installation as Rebar is used to build Erlang packages.
@@ -82,9 +97,10 @@ We are all set! Run your Phoenix application:
 
     $ cd hello_phoenix
     $ mix deps.get
+    $ mix ecto.create
     $ mix phoenix.server
 
-You can also run it inside IEx (Interactive Elixir) as:
+You can also run your app inside IEx (Interactive Elixir) as:
 
     $ iex -S mix phoenix.server
 ```


### PR DESCRIPTION
* Use "let's run `mix phoenix.new`" instead of "let's call
  `phoenix.new`"
* Show more output from the `mix phoenix.new` task and include the
  `Fetch and install dependencies? [Yn]`-line
* Split the output from `mix phoenix.new` only once, at the "Fetch and
  install dependencies"-prompt
* Split up `cd`-ing into the project directory, creating the database
  and starting the Phoenix server and include output
* Update output from `mix phoenix.server`