### PR TITLE
Added instructions for non default postgres passwords

### DIFF
--- a/bonus_guides/D_mix_tasks.md
+++ b/bonus_guides/D_mix_tasks.md
@@ -543,6 +543,15 @@ To fix this, we need to change the permissions on our "postgres" user to allow d
 ALTER ROLE
 ```
 
+If the "postgres" role is using a password different to the default "postgres", we'll get this error.
+
+```console
+$ mix ecto.create
+** (Mix) The database for HelloPhoenix.Repo couldn't be created, reason given: psql: FATAL:  password authentication failed for user "postgres"
+```
+
+To fix this, we can change the password in the environment specific configuration file. For development environment the password used can be found at the bottom of the `config/dev.exs` file.
+
 #### `ecto.drop`
 
 This task will drop the database specified in our repo. By default it will look for the repo named after our application (the one generated with our app unless we opted out of ecto). It will not prompt us to check if we're sure we want to drop the db, so do exercise caution.


### PR DESCRIPTION
Hey,

I was going through the Up and Running guide and ran into a problem with my non default postgres role password. Having a look in the ecto.create specific part of the documentation I found a whole host of error messages and their resolutions so I thought this might be a good addition?

I've attempted to keep to language similar to that used on description of the other issues.

Thanks,
.FxN