### PR TITLE
custom_errors: clarify example

### DIFF
--- a/bonus_guides/M_custom_errors.md
+++ b/bonus_guides/M_custom_errors.md
@@ -79,3 +79,5 @@ defimpl Plug.Exception, for: Ecto.NoResultsError do
   def status(_exception), do: 404
 end
 ```
+
+Note that this is just an example: Phoenix [already does this](https://github.com/phoenixframework/phoenix_ecto/blob/master/lib/phoenix_ecto/plug.ex) for `Ecto.NoResultsError`, so you don't have to.


### PR DESCRIPTION
Confused by the fact that you don't see the error page in dev (I think I'll make a separate PR about that), I added this handling in myself and got an "redefining" warning.