### PR TITLE
Changed exrm version from 0.15.3 to 0.19.9

### DIFF
--- a/deployment/I_exrm_releases.md
+++ b/deployment/I_exrm_releases.md
@@ -24,7 +24,7 @@ Let's separate our release process into a few tasks so we can keep track of wher
 
 ## Add exrm as a Dependency
 
-To get started, we'll need to add `{:exrm, "~> 0.15.3"}` into the list of dependencies in our `mix.exs` file.
+To get started, we'll need to add `{:exrm, "~> 0.19.9"}` into the list of dependencies in our `mix.exs` file.
 
 ```elixir
   defp deps do


### PR DESCRIPTION
There was a warning when compiling exrm 0.15.3 
warning: the dependency :exrm requires Elixir ">= 0.15.1 and ~> 1.0.0" but you are running on v1.1.1