### PR TITLE
Fix incorrect/missing code in find_message plug

### DIFF
--- a/DD_Plug.md
+++ b/DD_Plug.md
@@ -45,7 +45,7 @@ defmodule HelloPhoenix.MessageController do
           nil ->
             conn |> put_flash(:info, "That message wasn't found") |> redirect(to: "/")
           message ->
-            case authorize_message(conn, params["id"])
+            case authorize_message(conn, params["id"]) do
               :ok ->
                 render conn, :show, page: find_message(params["id"])
               :error ->
@@ -83,7 +83,7 @@ defmodule HelloPhoenix.MessageController do
   end
 
   defp find_message(conn, _) do
-    case find_message(params["id"]) do
+    case find_message(conn.params["id"]) do
       nil ->
         conn |> put_flash(:info, "That message wasn't found") |> redirect(to: "/") |> halt
       message ->


### PR DESCRIPTION
I was using the Plug guide as a reference and it appeared that `params` would be available in my plug based on this guide. I then got a `function params/0 undefined` error. Changing my plug to reference `conn.params` instead gave me what I was looking for.

There was also a missing `do` at the end of one of the `case` statements.