### PR TITLE
Upgrade section of guides

### DIFF
--- a/upgrading/A_0-16-to-0-17.md
+++ b/upgrading/A_0-16-to-0-17.md
@@ -1,0 +1,67 @@
+This guide will walk you through the steps to upgrade your Phoenix application from 0.16.x to 0.17.x.
+
+## Deps
+
+Bump your `:phoenix` and `:phoenix_live_reload` deps in `mix.exs`:
+
+```elixir
+def deps do
+  [...
+   {:phoenix, "~> 0.17"},
+   {:phoenix_live_reload, "~> 1.0"},
+  ...]
+end
+```
+
+## Endpoint
+
+The `:render_errors: [default_format: "html"]` is deprecated in favor of `render_errors: [accepts: ["html"]]`. Update your deprecated references in `config/*.exs`
+
+`plug :router` is no longer needed and has been removed. Update your `plug :router, Myapp.Router` to `plug Myapp.Router`.
+
+## Controller
+
+The "format" param for overriding the accept header has been renamed to "\_format" and is no longer injected into the params when parsing the Accept headers. Use `get_format/1` to access the negotiated format. If you were relying on the format param being present to match in the controller, such as:
+
+```elixir
+def show(conn, %{"id" => id, "format" => "html"}) do ...
+```
+
+You can still support this style by using a simple plug to place the format param. For example:
+
+```elixir
+defmodule MyApp.Router do
+
+  pipeline :browser do
+    ...
+    plug :put_format_param
+  end
+  
+  ...
+  defp put_format_param(conn, _) do
+    put_in conn.params["_format"], Phoenix.Controller.get_format(conn)
+  end
+end
+```
+
+## ChannelTest
+
+In order to test channels, one must now explicitly create a socket and pass it to subscribe_and_join. For example,
+
+    subscribe_and_join(MyChannel, "my_topic")
+    
+should now become
+
+```elixir
+socket() |> subscribe_and_join(MyChannel, "my_topic")
+# or
+socket("user:id", %{user_id: 13}) |> subscribe_and_join(MyChannel, "my_topic")
+```
+
+This pairs nicely with testing the UserSocket by simply call the module directly, for exampe:
+
+```elixir
+{:ok, _, socket} =
+  UserSocket.connect(%{"some" => "params"}, socket())
+  |> subscribe_and_join(RoomChannel, "rooms:lobby", %{"id" => 3})
+```


### PR DESCRIPTION
Rather than having the (rather excellent) upgrade guides hidden away in Gists by @chrismccord, I think they should be made a prominent feature of the guides (similar to how Rails has an [upgrading guide](http://guides.rubyonrails.org/upgrading_ruby_on_rails.html)).

I've added an example of one of those guides here and want to open this PR and discussion before I go doing any more work on it.