### PR TITLE
Minor typo, should likely read "common imports"

### DIFF
--- a/F_templates.md
+++ b/F_templates.md
@@ -10,7 +10,7 @@ We've already seen several ways in which templates are used, notably in the [Add
 
 ##### web.ex
 
-Phoenix generates a `web/web.ex` file that serves as place to group commons imports and aliases. All declarations here within the `view` block apply to all your templates.
+Phoenix generates a `web/web.ex` file that serves as place to group common imports and aliases. All declarations here within the `view` block apply to all your templates.
 
 Let's make some additions to our application so we can experiment a little.
 


### PR DESCRIPTION
This is a suggested correction to what appears to be a minor typo in the Templates Guide. The current wording is "commons imports", which should likely read "common imports".