### PR TITLE
Adjusting nested scopes examples in Routing Guide

### DIFF
--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -298,3 +298,35 @@ In fact, we can run anything using the `heroku run` command, like the Ecto migra
 ```console
 $ heroku run mix ecto.migrate
 ```
+
+## Troubleshooting
+
+### Compilation Error
+
+If you are getting compile error, that are not happening in your local machine, like this:
+
+```console
+remote: == Compilation error on file lib/postgrex/connection.ex ==
+remote: could not compile dependency :postgrex, "mix compile" failed. You can recompile this dependency with "mix deps.compile postgrex", update it with "mix deps.update postgrex" or clean it with "mix deps.clean postgrex"
+remote: ** (CompileError) lib/postgrex/connection.ex:207: Postgrex.Connection.__struct__/0 is undefined, cannot expand struct Postgrex.Connection
+remote:     (elixir) src/elixir_map.erl:58: :elixir_map.translate_struct/4
+remote:     (stdlib) lists.erl:1353: :lists.mapfoldl/3
+remote:     (stdlib) lists.erl:1354: :lists.mapfoldl/3
+remote: 
+remote: 
+remote:  !     Push rejected, failed to compile elixir app
+remote: 
+remote: Verifying deploy...
+remote: 
+remote: !   Push rejected to mysterious-meadow-6277.
+remote: 
+To https://git.heroku.com/mysterious-meadow-6277.git
+```
+
+You should force heroku rebuild all your application, for this, you must add elixir_buildpack.config in your root application folder with this content:
+
+```
+always_rebuild=true
+```
+
+Commit this and try to push again to Heroku

--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -303,7 +303,7 @@ $ heroku run mix ecto.migrate
 
 ### Compilation Error
 
-If you are getting compile error, that are not happening in your local machine, like this:
+Occasionally, an application will compile locally, but not on Heroku. The compilation error on Heroku will look something like this:
 
 ```console
 remote: == Compilation error on file lib/postgrex/connection.ex ==
@@ -323,10 +323,10 @@ remote:
 To https://git.heroku.com/mysterious-meadow-6277.git
 ```
 
-You should force heroku rebuild all your application, for this, you must add elixir_buildpack.config in your root application folder with this content:
+This has to do with stale dependencies which are not getting recompiled properly. It's possible to force Heroku to recompile all dependencies on each deploy, which should fix this problem. The way to do it is to add a new file called `elixir_buildpack.config` at the root of the application. The file should contain this line:
 
 ```
 always_rebuild=true
 ```
 
-Commit this and try to push again to Heroku
+Commit this file to the repository and try to push again to Heroku.


### PR DESCRIPTION
Per issue #439, I've removed the nested scope from the example by modifying the code block and related prose mentioned.

I've also adjusted the prose earlier in the Guide that references a nested scope, which isn't as confusing as that mentioned by @chrismccord. That said, we could also potentially eliminate that example too. If so, LMK and I'll make that revision by removing the related prose/code block.