### PR TITLE
Removed 'also' because 'as well' is used later.

### DIFF
--- a/H_ecto_models.md
+++ b/H_ecto_models.md
@@ -173,7 +173,7 @@ end
 
 Our repo has two main tasks - to bring in all the common query functions from `Ecto.Repo` and to set the `otp_app` name equal to our application name.
 
-When `phoenix.new` generated our application, it also generated some basic configuration as well. Let's look at `config/dev.exs`.
+When `phoenix.new` generated our application, it generated some basic configuration as well. Let's look at `config/dev.exs`.
 
 ```elixir
 . . .


### PR DESCRIPTION
This is merely to remove a redundant word. :smile:

Thanks for the excellent docs.