### PR TITLE
Update CONTRIBUTING.md and added description about @ in templates guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,11 @@ and configure the remotes:
 
 ```bash
 # Clone your fork of the repo into the current directory
-git clone https://github.com/<your-username>/phoenix-guides
+git clone https://github.com/<your-username>/phoenix_guides
 # Navigate to the newly cloned directory
-cd phoenix-guides
+cd phoenix_guides
 # Assign the original repo to a remote called "upstream"
-git remote add upstream https://github.com/phoenixframework/phoenix-guides
+git remote add upstream https://github.com/phoenixframework/phoenix_guides
 ```
 
 2. If you cloned a while ago, get the latest changes from upstream:

--- a/F_templates.md
+++ b/F_templates.md
@@ -139,7 +139,7 @@ Let's turn this display snippet into its own template. Let's create a new templa
 <p><%= @key %></p>
 ```
 
-We need to change `key` to `@key` here because this is a new template, not part of a list comprehension. The way we pass data into a template is by the `assigns` map, and the way we get the values out of the `assigns` map is by referencing the keys with a preceding `@`.
+We need to change `key` to `@key` here because this is a new template, not part of a list comprehension. The way we pass data into a template is by the `assigns` map, and the way we get the values out of the `assigns` map is by referencing the keys with a preceding `@`. `@` is actually a macro that translates `@key` to `<%= {:ok, v} = Access.fetch(assigns, :key); v %>`.
 
 Now that we have a template, we simply render it within our list comprehension in the `test.html.eex` template.
 


### PR DESCRIPTION
I noticed the repository name was "phoenix-guides" in CONTRIBUTING.md and changed it.

Also, added a little bit of explanation about the `@` macro in the templates guides.