### PR TITLE
updated deps to use mariaex ~> 0.6.1

### DIFF
--- a/bonus_guides/E_using_mysql.md
+++ b/bonus_guides/E_using_mysql.md
@@ -25,7 +25,7 @@ defmodule HelloPhoenix.Mixfile do
   defp deps do
     [{:phoenix, "~> 1.1.0"},
      {:phoenix_ecto, "~> 2.0"},
-     {:mariaex, ">= 0.0.0"},
+     {:mariaex, "~> 0.6.1", override: true},
      {:phoenix_html, "~> 2.3"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:cowboy, "~> 1.0"}]


### PR DESCRIPTION
To workaround an issue with MySQL where `mix ecto.migrate` will run infinitely without feedback. This is very frustrating for beginners. The error is already described here: https://github.com/elixir-lang/ecto/issues/1130. I think this will help a lot of people starting with Phoenix and MySQL.