### PR TITLE
Use to_string(k) for put_resp_header

### DIFF
--- a/DD_Plug.md
+++ b/DD_Plug.md
@@ -12,7 +12,7 @@ In order to act as a plug, a function simply needs to accept a connection struct
 ```elixir
 def put_headers(conn, key_values) do
   Enum.reduce key_values, conn, fn {k, v}, conn ->
-    Plug.Conn.put_resp_header(conn, k, v)
+    Plug.Conn.put_resp_header(conn, to_string(k), v)
   end
 end
 ```


### PR DESCRIPTION

I was following the guide and the example for "put_headers" produced the error: no function clause matching in Plug.Conn.put_resp_header/3.

I figured this was because the key of the map was an atom, and put_resp_header expects a binary. So I converted to atom to_string and it worked.

If there's a better way to do this, I look forward to hear about that.

- Elixir 1.2.3 on Windows