### PR TITLE
Remove 'recently' from ErrorView docs

### DIFF
--- a/E_views.md
+++ b/E_views.md
@@ -164,7 +164,7 @@ This is where the view module and its template from the controller are rendered 
 
 ### The ErrorView
 
-Phoenix recently added a new view to every generated application, the `ErrorView` which lives in `web/views/error_view.ex`. The purpose of the `ErrorView` is to handle two of the most common errors - `404 not found` and `500 internal error` - in a general way, from one centralized location. Let's see what it looks like.
+Phoenix has a view called the `ErrorView` which lives in `web/views/error_view.ex`. The purpose of the `ErrorView` is to handle two of the most common errors - `404 not found` and `500 internal error` - in a general way, from one centralized location. Let's see what it looks like.
 
 ```elixir
 defmodule HelloPhoenix.ErrorView do


### PR DESCRIPTION
Leaving in 'recently' might leave people reading this down the road that it is a brand new feature. The first commit where this was added appears to be phoenixframework/phoenix@bad7397f, which was committed Nov 29, 2014.