### PR TITLE
add ssl to heroku database config

### DIFF
--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -105,7 +105,8 @@ Then, we'll add the production database configuration to `config/prod.exs`:
 config :hello_phoenix, HelloPhoenix.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: System.get_env("DATABASE_URL"),
-  pool_size: 20
+  pool_size: 20,
+  ssl: true
 ```
 
 Now, let's tell Phoenix to use our Heroku URL and enforce we only use the SSL version of the website. Find the url line:
@@ -148,7 +149,8 @@ config :logger, level: :info
 config :hello_phoenix, HelloPhoenix.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: System.get_env("DATABASE_URL"),
-  pool_size: 20
+  pool_size: 20,
+  ssl: true
 ```
 
 ## Creating Environment Variables in Heroku


### PR DESCRIPTION
Heroku Postgres requires SSL when connecting to databases:
https://devcenter.heroku.com/articles/heroku-postgresql#heroku-postgres-ssl

This updates the Heroku deployment guide to instruct users to enable SSL on their Ecto Postgres setup.