### PR TITLE
Note to decrease ws timeout for Heroku deployment

### DIFF
--- a/deployment/E_heroku.md
+++ b/deployment/E_heroku.md
@@ -151,6 +151,22 @@ config :hello_phoenix, HelloPhoenix.Repo,
   pool_size: 20
 ```
 
+Finally, we need to decrease the timeout for the websocket transport:
+
+```elixir
+defmodule HelloPhoenix.UserSocket do
+  use Phoenix.Socket
+
+  ...
+
+  ## Transports
+  transport :websocket, Phoenix.Transports.WebSocket,
+    timeout: 45_000
+end
+```
+
+This ensures that any idle connections are closed by Phoenix before they reach Heroku's 55 second timeout window.
+
 ## Creating Environment Variables in Heroku
 
 The `DATABASE_URL` config var is automatically created by Heroku when we add the [Heroku Postgres add-on](https://elements.heroku.com/addons/heroku-postgresql). We can create the database via the heroku toolbelt:


### PR DESCRIPTION
We were seeing H15 errors on a production application. Based on a conversation with @chrismccord we figured out that we simply needed to lower the websocket timeout window to less then Heroku's 55 second window. In this case that was 45 seconds. Since this was such an easy fix I thought that the information might be helpful to others. Let me know what you think.