### PR TITLE
Remove duplicate reviews path in routing guide

### DIFF
--- a/C_routing.md
+++ b/C_routing.md
@@ -716,7 +716,7 @@ defmodule HelloPhoenix.Router do
     # Use the default browser stack.
     pipe_through [:browser, :review_checks, :other_great_stuff]
 
-    resources "/reviews", HelloPhoenix.ReviewController
+    resources "/", HelloPhoenix.ReviewController
   end
 end
 ```
@@ -745,7 +745,7 @@ defmodule HelloPhoenix.Router do
   scope "/reviews", HelloPhoenix do
     pipe_through [:browser, :review_checks]
 
-    resources "/reviews", ReviewController
+    resources "/", ReviewController
   end
 end
 ```
@@ -776,7 +776,7 @@ defmodule HelloPhoenix.Router do
   scope "/reviews", HelloPhoenix do
     pipe_through :review_checks
 
-    resources "/reviews", ReviewController
+    resources "/", ReviewController
   end
 end
 ```


### PR DESCRIPTION
When I say `duplicate`, I mean this:

`/reviews/reviews/`

In routing guide, we have codes like this:

    scope "/reviews" do
      # Use the default browser stack.
      pipe_through [:browser, :review_checks, :other_great_stuff]

      resources "/reviews", HelloPhoenix.ReviewController
    end

which generates the following paths:

    review_path  GET     /reviews/reviews           HelloPhoenix.ReviewController :index
    review_path  GET     /reviews/reviews/:id/edit  HelloPhoenix.ReviewController :edit
    review_path  GET     /reviews/reviews/new       HelloPhoenix.ReviewController :new
    review_path  GET     /reviews/reviews/:id       HelloPhoenix.ReviewController :show
    review_path  POST    /reviews/reviews           HelloPhoenix.ReviewController :create
    review_path  PATCH   /reviews/reviews/:id       HelloPhoenix.ReviewController :update
                 PUT     /reviews/reviews/:id       HelloPhoenix.ReviewController :update
    review_path  DELETE  /reviews/reviews/:id       HelloPhoenix.ReviewController :delete
 
I think it should be only:

        review_path  GET     /reviews          HelloPhoenix.ReviewController :index
        .
        .
        .

Am I right?