### PR TITLE
Provide a link to the .ez archives repo

### DIFF
--- a/introduction/E_installation.md
+++ b/introduction/E_installation.md
@@ -35,7 +35,7 @@ Here's the command to install the Phoenix archive:
 ```console
 $ mix archive.install https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez
 ```
-> Note: if the Phoenix archive won't install properly with this command, we can download the file directly from our browser, save it to the filesystem, and then run: `mix archive.install /path/to/local/phoenix_new.ez`.
+> Note: if the Phoenix archive won't install properly with this command, we can download the package from the [Phoenix archives](https://github.com/phoenixframework/archives), save it to the filesystem, and then run: `mix archive.install /path/to/local/phoenix_new.ez`.
 
 ### Plug, Cowboy, and Ecto
 


### PR DESCRIPTION
In the Introduction > Installation guide, I added a link to the Phoenix Framework `archives` GitHub repo. Readers can follow the link to download the exact Phoenix version they are looking for, including release candidates.