### PR TITLE
Mention Compilation of Assets for Production Deployment Before Summary

### DIFF
--- a/deployment/A_introduction.md
+++ b/deployment/A_introduction.md
@@ -49,6 +49,13 @@ import_config "/var/config.prod.exs"
 ```
 
 With your secret information properly secured, it is time to configure assets!
+Before taking this step, we need to do one bit of preparation.
+Since we will be readying everything for production, we need to do some setup in that environment by getting our dependencies and compiling.
+
+```console
+$ mix deps.get --only prod
+$ MIX_ENV=prod mix compile
+```
 
 ## Compiling your application assets
 


### PR DESCRIPTION
In reference to [Issue 467](https://github.com/phoenixframework/phoenix_guides/issues/467) it was mentioned that in the summary production grabbing and compilation of assets was a step in this section:

```
Overall, here is a script you can use as starting point:

```elixir
# Initial setup
$ mix deps.get --only prod
$ MIX_ENV=prod mix compile
...
```

But not in the initial part of the guide here or anywhere before:

```
...
## Compiling your application assets

This step is required only if you have static assets like images, javascript, stylesheets and more in your Phoenix applications. By default, Phoenix uses brunch, and that's what we are going to explore.

Compilation of static assets happens in two steps:


$ brunch build --production
$ MIX_ENV=prod mix phoenix.digest
Check your digested files at "priv/static".
...
```

So I've added the change you'll see in the diff to address this.

I see another approach is taken [here in #475] (https://github.com/phoenixframework/phoenix_guides/pull/475/files) that is a bit more open-ended with custom buildpacks.
Let me know if I should close or modify :) 