### PR TITLE
Add workaround for `exrm` bug

### DIFF
--- a/deployment/I_exrm_releases.md
+++ b/deployment/I_exrm_releases.md
@@ -125,7 +125,7 @@ Check your digested files at 'priv/static'.
 
 ### Generating the Release
 
-Now that we've configured our application, let's build our production release by running `MIX_ENV=prod mix release` at the root of our application.
+Now that we've configured our application, let's build our production release by running `MIX_ENV=prod mix compile` and then `MIX_ENV=prod mix release` at the root of our application.
 
 ```console
 $ MIX_ENV=prod mix release


### PR DESCRIPTION
`exrm` has a recent incompatibility with `mix` that is detailed in [this issue](https://github.com/bitwalker/exrm/issues/326). This update to the guide provides a workaround to that glitch by running `mix compile` before `mix release`.

Note that once the `exrm` issue is resolved, this step can be removed. I had a more verbose explanation of the error in the guide, but figured that the guide should be as clear and simple as possible for new users, so I worked it in as though it's a normal step.