### PR TITLE
add explicit debian instructions. Closes #477

### DIFF
--- a/introduction/E_installation.md
+++ b/introduction/E_installation.md
@@ -23,7 +23,9 @@ When we install Elixir using instructions from the Elixir [Installation Page](ht
 People using Debian-based systems may need to explicitly install Erlang to get all the needed packages.
 
 ```console
-$ sudo apt-get install erlang
+$ wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb
+$ sudo apt-get update
+$ sudo apt-get install esl-erlang
 ```
 
 ### Phoenix


### PR DESCRIPTION
In response to #477 this PR adds more explicit instructions for installing erlang on debian-based systems. It's pretty much a copy paste job of the instructions at elixir-lang.org.

That having been said, I think it's worth discussing if we should provide these instructions at all. The guide already say that you should follow the instructions at elixir-lang.org.

> If Erlang was not installed along with Elixir, please see the Erlang Instructions section of the Elixir Installation Page for instructions.

Those instructions are likely to be more up-to-date, so rather than repeating the instructions and taking the risk that these instructions might fall out of sync with the elixir-lang.org instructions maybe we should just omit the command line and leave it at "go over there and follow those instructions."