### PR TITLE
Add authenticate/1 and find_message/1 to Plug doc. (#442)

### DIFF
--- a/DD_Plug.md
+++ b/DD_Plug.md
@@ -73,6 +73,7 @@ defmodule HelloPhoenix.MessageController do
     render conn, :show, page: find_message(params["id"])
   end
 
+  defp authenticate(conn), do: ...
   defp authenticate(conn, _) do
     case Authenticator.find_user(conn) do
       {:ok, user} ->
@@ -82,6 +83,7 @@ defmodule HelloPhoenix.MessageController do
     end
   end
 
+  defp find_message(id), do: ...
   defp find_message(conn, _) do
     case find_message(conn.params["id"]) do
       nil ->


### PR DESCRIPTION
This issue has been open for a while, https://github.com/phoenixframework/phoenix_guides/issues/442

I haven't seen anyone disagree with the suggestions in the comments, so I added those in.  If we think something better could be in place, I'm happy to change it.