### PR TITLE
Fix link to PubSub docs in Channels guide.

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -28,7 +28,7 @@ Each Channel will implement one or more clauses of each of these four callback f
 
 The Phoenix PubSub layer consists of the `Phoenix.PubSub` module and a variety of modules for different adapters and their `GenServer`s. These modules contain functions which are the nuts and bolts of organizing Channel communication - subscribing to topics, unsubscribing from topics, and broadcasting messages on a topic.
 
-We can also define our own PubSub adapters if we need to. Please see the [Phoenix.PubSub docs](http://hexdocs.pm/phoenix/Phoenix.PubSub.html) for more information.
+We can also define our own PubSub adapters if we need to. Please see the [Phoenix.PubSub docs](https://hexdocs.pm/phoenix_pubsub) for more information.
 
 It is worth noting that these modules are intended for Phoenix's internal use. Channels use them under the hood to do much of their work. As end users, we shouldn't have any need to use them directly in our applications.
 


### PR DESCRIPTION
This PR fixes the broken link to Phoenix PubSub docs in the Channels guide.