### PR TITLE
Update `gen.channel` sample code

### DIFF
--- a/bonus_guides/D_mix_tasks.md
+++ b/bonus_guides/D_mix_tasks.md
@@ -360,7 +360,7 @@ $ mix phoenix.gen.model Admin.User users name:string age:integer
 This task will generate a basic Phoenix channel as well a test case for it. It takes only two arguments, the module name for the channel and plural used as the topic.
 
 ```console
-$ mix phoenix.gen.channel Room rooms
+$ mix phoenix.gen.channel Room
 * creating web/channels/room_channel.ex
 * creating test/channels/room_channel_test.exs
 ```


### PR DESCRIPTION
> $ mix phoenix.gen.channel Room rooms
> ** (Mix) mix phoenix.gen.channel expects just the module name:
>    mix phoenix.gen.channel Room
>
> $ mix phoenix.gen.channel Room
> ... works

Fixes https://github.com/phoenixframework/phoenix/issues/1907