### PR TITLE
Fix code example for composite keys

### DIFF
--- a/bonus_guides/EE_custom_primary_key.md
+++ b/bonus_guides/EE_custom_primary_key.md
@@ -145,8 +145,8 @@ defmodule HelloPhoenix.Player do
 
   @primary_key false
   schema "players" do
-    field :first_name, primary_key: true
-    field :last_name, primary_key: true
+    field :first_name, :string, primary_key: true
+    field :last_name, :string, primary_key: true
     field :position, :string
     field :number, :integer
   . . .


### PR DESCRIPTION
Guide for custom primary key had invalid code example. The code should had field type as second argument.