### PR TITLE
Add missing steps in manual Ecto setup for existing applications

### DIFF
--- a/H_ecto_models.md
+++ b/H_ecto_models.md
@@ -625,6 +625,15 @@ defmodule HelloPhoenix.Mixfile do
 end
 ```
 
+We also need to explicitly append both `:postgrex` and `:phoenix_ecto` in the list of applications.
+
+```elixir
+def application do
+    [mod: {HelloPhoenix, []},
+     applications: [:phoenix, :phoenix_pubsub, :phoenix_html, ... :postgrex, :phoenix_ecto]]
+end
+```
+
 Then we run `mix do deps.get, compile` to get them into our application.
 
 ```console
@@ -634,7 +643,7 @@ Dependency resolution completed successfully
 . . .
 ```
 
-The next piece we need to add is our application's repo. We can easily do that with the `ecto.gen.repo` task.
+The next piece we need to add is our application's repo. We can easily do that with the `ecto.gen.repo -r HelloPhoenix.Repo` task. 
 
 ```console
 $ mix ecto.gen.repo
@@ -648,6 +657,7 @@ supervisor(HelloPhoenix.Repo, [])
 ```
 
 Note: Please see the "Repo" section above for information on what the repo does.
+We will follow the instructions for the supervisor setup below.
 
 This task creates a directory for our repo as well as the repo itself.
 
@@ -667,6 +677,12 @@ database: "hello_phoenix_repo",
 username: "user",
 password: "pass",
 hostname: "localhost"
+```
+
+We have to further enhance our `config/config.exs` file by adding a new line which contains a list of `ecto_repos`. Here we just add our newly generated `HelloPhoenix.Repo`.
+
+```elixir
+config :hello_phoenix, ecto_repos: [HelloPhoenix.Repo] 
 ```
 
 We should also make sure to listen to the output of `ecto.gen.repo` and add our application repo as a child worker to our application's supervision tree.

--- a/H_ecto_models.md
+++ b/H_ecto_models.md
@@ -705,7 +705,7 @@ defmodule HelloPhoenix do
 end
 ```
 
-At last we want to be able to generate new models via [mix tasks](http://www.phoenixframework.org/docs/mix-tasks#section--mix-phoenix-gen-model-). Generated models expect to already use and import some modules from Ecto. We can load these dependencies globally by adding them to the `model` definition in  the `web/web.ex` file.
+Now that Ecto is configured, we can use the [mix tasks](http://www.phoenixframework.org/docs/mix-tasks#section--mix-phoenix-gen-model-) to generate models. By default all model files should have the line `use HelloPhoenix.Web, :model` which handles the imports, but does not yet contain the `Ecto` dependencies. We can define or append the `model` function in the `web/web.ex` file:
 
 ```elixir
   def model do
@@ -719,8 +719,5 @@ At last we want to be able to generate new models via [mix tasks](http://www.pho
     end
   end
 ```
-
-By default all model files should generate with `use HelloPhoenix.Web, :model` which will add `use Ecto.Schema`, `import Ecto`, `import Ecto.Changeset` and `import Ecto.Query` automatically.
-
 
 At this point, we are completely configured and ready to go. We can go back to the top of this guide and follow along.

--- a/H_ecto_models.md
+++ b/H_ecto_models.md
@@ -705,4 +705,22 @@ defmodule HelloPhoenix do
 end
 ```
 
+At last we want to be able to generate new models via [mix tasks](http://www.phoenixframework.org/docs/mix-tasks#section--mix-phoenix-gen-model-). Generated models expect to already use and import some modules from Ecto. We can load these dependencies globally by adding them to the `model` definition in  the `web/web.ex` file.
+
+```elixir
+  def model do
+    quote do
+      # Define common model functionality
+      use Ecto.Schema
+
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+    end
+  end
+```
+
+By default all model files should generate with `use HelloPhoenix.Web, :model` which will add `use Ecto.Schema`, `import Ecto`, `import Ecto.Changeset` and `import Ecto.Query` automatically.
+
+
 At this point, we are completely configured and ready to go. We can go back to the top of this guide and follow along.


### PR DESCRIPTION
I noticed that the guide just adds the the dependencies to `deps`, but they are not listed in the application dependencies. 
This will result in startup errors which might discourage new users joining the ecosystem.

Furthermore it contains the changes for Ecto 3, which are also mentioned in the [migration guide](http://www.phoenixframework.org/blog/upgrading-from-11x-to-120).
