### PR TITLE
Fix brunch docs link on the static assets guide

### DIFF
--- a/bonus_guides/G_static_assets.md
+++ b/bonus_guides/G_static_assets.md
@@ -230,7 +230,7 @@ There are many more nice tricks we can do with Brunch which are not covered in t
 - Instead of manually copying third-party libraries into `web/static/vendor` we can [use Bower to download and install them](https://github.com/brunch/brunch-guide/blob/master/content/en/chapter05-using-third-party-registries.md).
 
 
-Should we want one of these, please read [the Brunch documentation](https://github.com/brunch/brunch/tree/master/docs).
+Should we want one of these, please read [the Brunch documentation](http://brunch.io/docs/getting-started).
 
 #### Phoenix Without Brunch
 


### PR DESCRIPTION
The documentation was moved out of the main repo, so point the reference to the getting started guide on the website instead.

https://github.com/brunch/brunch/pull/1376