### PR TITLE
Change meta code in eex

### DIFF
--- a/B_adding_pages.md
+++ b/B_adding_pages.md
@@ -254,7 +254,7 @@ And this is what the template should look like:
 </div>
 ```
 
-Our messenger appears as `@messenger`. In this case, this is not a module attribute. It is special bit of metaprogrammed syntax which stands in for `Dict.get(assigns, :messenger)`. The result is much nicer on the eyes and much easier to work with in a template.
+Our messenger appears as `@messenger`. In this case, this is not a module attribute. It is special bit of metaprogrammed syntax which stands in for `Map.get(assigns, :messenger)`. The result is much nicer on the eyes and much easier to work with in a template.
 
 We're done. If you point your browser here: [http://localhost:4000/hello/Frank](http://localhost:4000/hello/Frank), you should see a page that looks like this:
 

--- a/F_templates.md
+++ b/F_templates.md
@@ -139,7 +139,7 @@ Let's turn this display snippet into its own template. Let's create a new templa
 <p><%= @key %></p>
 ```
 
-We need to change `key` to `@key` here because this is a new template, not part of a list comprehension. The way we pass data into a template is by the `assigns` map, and the way we get the values out of the `assigns` map is by referencing the keys with a preceding `@`. `@` is actually a macro that translates `@key` to `<%= {:ok, v} = Access.fetch(assigns, :key); v %>`.
+We need to change `key` to `@key` here because this is a new template, not part of a list comprehension. The way we pass data into a template is by the `assigns` map, and the way we get the values out of the `assigns` map is by referencing the keys with a preceding `@`. `@` is actually a macro that translates `@key` to `Map.get(assigns, :key)`.
 
 Now that we have a template, we simply render it within our list comprehension in the `test.html.eex` template.
 


### PR DESCRIPTION
I find using `Dict` in Phoenix Guides.

`Dict` is deprecated type. So, Removed `Dict` in EEx.
https://github.com/elixir-lang/elixir/commit/94a07df8d3879f8555b75ba4326bc593cc0361b7

Replaced code in Phoenix Guides.
Please, check it.