### PR TITLE
Add simple mix.exs to allow previewing guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /_build
 /deps
+/doc
 erl_crash.dump
 .sass-cache
 *.ez

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,35 @@
+defmodule PhoenixGuides.Mixfile do
+  use Mix.Project
+
+  @version "1.3.0-dev"
+
+  def project do
+    [app: :phoenix_guides,
+     name: "Phoenix Guides",
+     version: @version,
+     elixir: "~> 1.3",
+     deps: deps(),
+     docs: [source_ref: "v#{@version}",
+            main: "overview",
+            logo: "styling/Phoenix_files/phoenix-logo-white.png",
+            assets: "images",
+            extra_section: "GUIDES",
+            extras: extras(),
+            homepage_url: "http://www.phoenixframework.org",
+            description: """
+            Phoenix Guides - Preview - The guides are published from the phoenixframework/phoenix project, not separately, however this config exists to make it easier to preview changes to the guides without also building the framework source API docs.
+            """]]
+  end
+
+  def application do
+    []
+  end
+
+  defp deps do
+    [{:ex_doc, "~> 0.14", only: :docs}]
+  end
+
+  defp extras do
+    System.cwd() |> Path.join("docs/**/*.md") |> Path.wildcard()
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
This is intended for the ex_doc branch.

Rather than duplicating the 'extras' config here, just pick up all the .md files and generate the html so that contributors can preview changes easily.

Also, ignore the generated /doc directory.

Note: this won't work until the .md files are moved under the docs/ directory (which I believe is the plan...)