### PR TITLE
Add missing "the"

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -256,7 +256,7 @@ Clients subscribe to topics, and Phoenix stores those subscriptions in an in-mem
 
 - Resending Client Messages
 
-Channel clients queue outgoing messages into a `PushBuffer`, and send them to server when there is a connection. If no connection is available, the client holds on to the messages until it can establish a new connection. With no connection, the client will hold the messages in memory until it establishes a connection, or until it receives a `timeout` event. The default timeout is set to 5000 milliseconds. The client won't persist the messages in the browser's local storage, so if the browser tab closes, the messages will be gone.
+Channel clients queue outgoing messages into a `PushBuffer`, and send them to the server when there is a connection. If no connection is available, the client holds on to the messages until it can establish a new connection. With no connection, the client will hold the messages in memory until it establishes a connection, or until it receives a `timeout` event. The default timeout is set to 5000 milliseconds. The client won't persist the messages in the browser's local storage, so if the browser tab closes, the messages will be gone.
 
 - Resending Server Messages
 


### PR DESCRIPTION
In [Fault Tolerance and Reliability Guarantees](http://www.phoenixframework.org/docs/channels#section-fault-tolerance-and-reliability-guarantees), second bullet point (*Resending Client Messages*):

> Channel clients [...] send them to **the** server [...].