### PR TITLE
Fix typo to say 'pattern match'

### DIFF
--- a/testing/G_controllers.md
+++ b/testing/G_controllers.md
@@ -106,7 +106,7 @@ defmodule HelloPhoenix.UserControllerTest do
     assert response == expected
   end
 ```
-Let's take a look at what's going on here. Each test gets a map with a test conn passed into it, so we pattern much on that to get our conn.  We build our users, and use the `get` function to make a `GET` request to our `UserController` index action, which is piped into `json_response/2` along with the expected HTTP status code.  This will return the JSON from the response body, when everything is wired up properly. We represent the JSON we want the controller action to return with the variable `expected`, and assert that the `response` and `expected` are the same.
+Let's take a look at what's going on here. Each test gets a map with a test conn passed into it, so we pattern match on that to get our conn.  We build our users, and use the `get` function to make a `GET` request to our `UserController` index action, which is piped into `json_response/2` along with the expected HTTP status code.  This will return the JSON from the response body, when everything is wired up properly. We represent the JSON we want the controller action to return with the variable `expected`, and assert that the `response` and `expected` are the same.
 
 Our expected data is a JSON response with a top level key of `"data"` containing an array of users that have `"name"` and `"email"` properties.
 


### PR DESCRIPTION
Previously said "pattern much"