### PR TITLE
Set preferred environment for mix docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule PhoenixGuides.Mixfile do
      version: @version,
      elixir: "~> 1.3",
      deps: deps(),
+     preferred_cli_env: [docs: :docs],
      docs: [source_ref: "v#{@version}",
             main: "overview",
             logo: "styling/Phoenix_files/phoenix-logo-white.png",


### PR DESCRIPTION
This sets the preferred environment for `mix docs` so that you do not have to type `MIX_ENV=docs` every time.