### PR TITLE
Correct render arity in views guide

### DIFF
--- a/E_views.md
+++ b/E_views.md
@@ -306,7 +306,7 @@ defmodule HelloPhoenix.PageController do
 end
 ```
 
-Here, we have our `show/2` and `index/2` actions returning static page data. Instead of passing in `"show.html"` to `render/2` as the template name, we pass `"show.json"`.  This way, we can have views that are responsible for rendering HTML as well as JSON by pattern matching on different file types.
+Here, we have our `show/2` and `index/2` actions returning static page data. Instead of passing in `"show.html"` to `render/3` as the template name, we pass `"show.json"`.  This way, we can have views that are responsible for rendering HTML as well as JSON by pattern matching on different file types.
 
 ```elixir
 defmodule HelloPhoenix.PageView do


### PR DESCRIPTION
This PR just corrects the arity referenced in the views guide from `render/2` -> `render/3`. The `show` action in the example invokes `render` with three arguments.

![image](https://cloud.githubusercontent.com/assets/4386645/19623660/8a0c8236-988f-11e6-89f6-680b1eee6638.png)
