### PR TITLE
Update headers on Plug docs and fix links

### DIFF
--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -2,7 +2,7 @@
 
 Phoenix controllers act as intermediary modules. Their functions - called actions - are invoked from the router in response to HTTP requests. The actions, in turn, gather all the necessary data and perform all the necessary steps before invoking the view layer to render a template or returning a JSON response.
 
-Phoenix controllers also build on the Plug package, and are themselves plugs. Controllers provide the functions to do almost anything we need to in an action. If we do find ourselves looking for something that Phoenix controllers don't provide; however, we might find what we're looking for in Plug itself. Please see the [Plug Guide](http://www.phoenixframework.org/docs/understanding-plug) or [Plug Documentation](http://hexdocs.pm/plug/) for more information.
+Phoenix controllers also build on the Plug package, and are themselves plugs. Controllers provide the functions to do almost anything we need to in an action. If we do find ourselves looking for something that Phoenix controllers don't provide; however, we might find what we're looking for in Plug itself. Please see the [Plug Guide](plug.html) or [Plug Documentation](http://hexdocs.pm/plug/) for more information.
 
 A newly generated Phoenix app will have a single controller, the `PageController`, which can be found at `web/controllers/page_controller.ex` and looks like this.
 

--- a/docs/introduction/overview.md
+++ b/docs/introduction/overview.md
@@ -54,7 +54,7 @@ Phoenix takes great advantage of Plug in general - the router and controllers es
 
 One of the most important things about Plug is that it provides adapters to HTTP servers which will ultimately deliver application content to our users. Currently Plug only provides an adapter for [Cowboy](https://github.com/ninenines/cowboy), a web server written in Erlang by Loïc Hoguin of [99s](http://ninenines.eu/).
 
-Have a look at the [Plug Guide](http://www.phoenixframework.org/docs/understanding-plug) for more details.
+Have a look at the [Plug Guide](plug.html) for more details.
 
 ### Ecto
 

--- a/docs/plug.md
+++ b/docs/plug.md
@@ -8,7 +8,7 @@ Plug lives at the heart of Phoenix's HTTP layer, and Phoenix puts Plug front and
 
 At the simplest level, the Plug specification comes in two flavors, *function plugs* and *module plugs*
 
-### Function Plugs
+## Function Plugs
 In order to act as a plug, a function simply needs to accept a connection struct (`%Plug.Conn{}`) and options. It also needs to return the connection struct. Any function that meets those criteria will do. Here's an example.
 
 ```elixir
@@ -109,7 +109,7 @@ By replacing the nested blocks of code with a flattened series of plug transform
 
 Now let's look at the other flavor plugs come in, module plugs.
 
-### Module Plugs
+## Module Plugs
 
 Module plugs are another type of Plug that let us define a connection transformation in a module. The module only needs to implement two functions:
 


### PR DESCRIPTION
- Use h2's on Plug docs so the items will show in the left-hand menu
- Use relative links to plug.html instead of full urls