### PR TITLE
Use relative urls instead of absolute urls

### DIFF
--- a/docs/adding_pages.md
+++ b/docs/adding_pages.md
@@ -126,7 +126,7 @@ end
 
 ```
 
-For now, we'll ignore the pipelines and the use of `scope` here and just focus on adding a route. (We cover these topics in the [Routing Guide](http://www.phoenixframework.org/docs/routing), if you're curious.)
+For now, we'll ignore the pipelines and the use of `scope` here and just focus on adding a route. (We cover these topics in the [Routing Guide](routing.html), if you're curious.)
 
 Let's add a new route to the router that maps a `GET` request for `/hello` to the `index` action of a soon-to-be-created `HelloPhoenix.HelloController`:
 
@@ -160,7 +160,7 @@ defmodule HelloPhoenix.HelloController do
   end
 end
 ```
-We'll save a discussion of `use HelloPhoenix.Web, :controller` for the [Controllers Guide](http://www.phoenixframework.org/docs/controllers). For now, let's focus on the `index/2` action.
+We'll save a discussion of `use HelloPhoenix.Web, :controller` for the [Controllers Guide](controllers.html). For now, let's focus on the `index/2` action.
 
 All controller actions take two arguments. The first is `conn`, a struct which holds a ton of data about the request. The second is `params`, which are the request parameters. Here, we are not using `params`, and we avoid compiler warnings by adding the leading `_`.
 

--- a/docs/bonus_guides/custom_errors.md
+++ b/docs/bonus_guides/custom_errors.md
@@ -39,7 +39,7 @@ config :hello_phoenix, HelloPhoenix.Endpoint,
   watchers: [node: ["node_modules/brunch/bin/brunch", "watch"]]
 ```
 
-To learn more about custom error pages, please see [The Error View](http://www.phoenixframework.org/docs/views#section-the-errorview) section of the View Guide.
+To learn more about custom error pages, please see [The Error View](views.html#the-errorview) section of the View Guide.
 
 #### Custom Errors
 

--- a/docs/bonus_guides/file_uploads.md
+++ b/docs/bonus_guides/file_uploads.md
@@ -6,7 +6,7 @@ Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `
 
 Let's take this one piece at a time.
 
-In the [`Ecto Models Guide`](http://www.phoenixframework.org/docs/ecto-models), we generated an HTML resource for users. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please see that guide for instructions on generating the users resource we'll be using here.
+In the [`Ecto Models Guide`](ecto_models.html), we generated an HTML resource for users. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please see that guide for instructions on generating the users resource we'll be using here.
 
 The first thing we need to do is change our form into a multipart form. The `form_for/4` function accepts a keyword list of options where we can specify this.
 

--- a/docs/bonus_guides/mix_tasks.md
+++ b/docs/bonus_guides/mix_tasks.md
@@ -22,7 +22,7 @@ We have seen all of these at one point or another in the guides, but having all 
 
 #### `mix phoenix.new`
 
-This is how we tell Phoenix the framework to generate a new Phoenix application for us. We saw it early on in the [Up and Running Guide](http://www.phoenixframework.org/docs/up-and-running).
+This is how we tell Phoenix the framework to generate a new Phoenix application for us. We saw it early on in the [Up and Running Guide](up_and_running.html).
 
 Before we begin, we should note that Phoenix uses [Ecto](https://github.com/elixir-lang/ecto) for database access and [Brunch.io](http://brunch.io/) for asset management by default. We can pass `--no-ecto` to opt out of Ecto and  `--no-brunch` to opt out of Brunch.io.
 
@@ -390,7 +390,7 @@ $ web/channels/presence.ex
 
 #### `mix phoenix.routes`
 
-This task has a single purpose, to show us all the routes defined for a given router. We saw it used extensively in the [Routing Guide](http://www.phoenixframework.org/docs/routing).
+This task has a single purpose, to show us all the routes defined for a given router. We saw it used extensively in the [Routing Guide](routing.html).
 
 If we don't specify a router for this task, it will default to the router Phoenix generated for us.
 

--- a/docs/bonus_guides/seeding_data.md
+++ b/docs/bonus_guides/seeding_data.md
@@ -4,7 +4,7 @@ When creating an app, it's important that we're able to seed our datastore with 
 
 Fortunately, Phoenix already provides us with a convention for seeding data. By default Phoenix generates a script file for each app at `priv/repo/seeds.exs`, which we can use to populate our datastore.
 
-Also note that in order to seed data as in the example below you should have already generated and run the related migration (i.e., Link migration, controller, model, etc.) and updated your `router.ex`, as described in the [Ecto Models Guide](http://www.phoenixframework.org/docs/ecto-models) (if you haven't completed that Guide yet, you should do so before proceeding further).
+Also note that in order to seed data as in the example below you should have already generated and run the related migration (i.e., Link migration, controller, model, etc.) and updated your `router.ex`, as described in the [Ecto Models Guide](ecto_models.html) (if you haven't completed that Guide yet, you should do so before proceeding further).
 
 So in order to seed data, we simply need to add a script to `seeds.exs` that uses our datastore to directly add the data we want. As you can see from the comments that Phoenix generated for us in `seeds.exs` file, we should follow this pattern:
 

--- a/docs/bonus_guides/sending_email_with_mailgun.md
+++ b/docs/bonus_guides/sending_email_with_mailgun.md
@@ -86,7 +86,7 @@ import_config "#{Mix.env}.exs"
 import_config "config.secret.exs"
 ```
 
-Since our `config/config.secret.exs` file won't be in our repository, we'll need to take some extra steps when we deploy our application. Please see the [Deployment Introduction Guide](http://www.phoenixframework.org/docs/deployment) for more information.
+Since our `config/config.secret.exs` file won't be in our repository, we'll need to take some extra steps when we deploy our application. Please see the [Deployment Introduction Guide](deployment.html) for more information.
 
 ### The Client Module
 

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -47,7 +47,7 @@ defmodule HelloPhoenix.PageController do
 end
 ```
 
-While we can name our actions whatever we like, there are conventions for action names which we should follow whenever possible. We went over these in the [Routing Guide](http://www.phoenixframework.org/docs/routing), but we'll take another quick look here.
+While we can name our actions whatever we like, there are conventions for action names which we should follow whenever possible. We went over these in the [Routing Guide](routing.html), but we'll take another quick look here.
 
 - index   - renders a list of all items of the given resource type
 - show    - renders an individual item by id
@@ -61,7 +61,7 @@ Each of these actions takes two parameters, which will be provided by Phoenix be
 
 The first parameter is always `conn`, a struct which holds information about the request such as the host, path elements, port, query string, and much more. `conn`, comes to Phoenix via Elixir's Plug middleware framework. More detailed info about `conn` can be found in [plug's documentation](http://hexdocs.pm/plug/Plug.Conn.html).
 
-The second parameter is `params`. Not surprisingly, this is a map which holds any parameters passed along in the HTTP request. It is a good practice to pattern match against params in the function signature to provide data in a simple package we can pass on to rendering. We saw this in the [Adding Pages guide](http://www.phoenixframework.org/docs/adding-pages) when we added a messenger parameter to our `show` route in `web/controllers/hello_controller.ex`.
+The second parameter is `params`. Not surprisingly, this is a map which holds any parameters passed along in the HTTP request. It is a good practice to pattern match against params in the function signature to provide data in a simple package we can pass on to rendering. We saw this in the [Adding Pages guide](adding_pages.html) when we added a messenger parameter to our `show` route in `web/controllers/hello_controller.ex`.
 
 ```elixir
 defmodule HelloPhoenix.HelloController do
@@ -77,7 +77,7 @@ In some cases - often in `index` actions, for instance - we don't care about par
 
 ### Gathering Data
 
-While Phoenix does not ship with its own data access layer, the Elixir project [Ecto](http://hexdocs.pm/ecto) provides a very nice solution for those using the [Postgres](http://www.postgresql.org/) relational database. We cover how to use Ecto in a Phoenix project in the [Ecto Models Guide](http://www.phoenixframework.org/docs/ecto-models). Databases supported by Ecto are covered in the [Usage section of the Ecto README](https://github.com/elixir-lang/ecto#usage).
+While Phoenix does not ship with its own data access layer, the Elixir project [Ecto](http://hexdocs.pm/ecto) provides a very nice solution for those using the [Postgres](http://www.postgresql.org/) relational database. We cover how to use Ecto in a Phoenix project in the [Ecto Models Guide](ecto_models.html). Databases supported by Ecto are covered in the [Usage section of the Ecto README](https://github.com/elixir-lang/ecto#usage).
 
 Of course, there are many other data access options. [Ets](http://www.erlang.org/doc/man/ets.html) and [Dets](http://www.erlang.org/doc/man/dets.html) are key value data stores built into [OTP](http://www.erlang.org/doc/). OTP also provides a relational database called [mnesia](http://www.erlang.org/doc/man/mnesia.html) with its own query language called QLC. Both Elixir and Erlang also have a number of libraries for working with a wide range of popular data stores.
 
@@ -170,7 +170,7 @@ For this, Phoenix provides the `render/3` function.
 
 Interestingly, `render/3` is defined in the `Phoenix.View` module instead of `Phoenix.Controller`, but it is aliased in `Phoenix.Controller` for convenience.
 
-We have already seen the render function in the [Adding Pages Guide](http://www.phoenixframework.org/docs/adding-pages). Our `show` action in `web/controllers/hello_controller.ex` looked like this.
+We have already seen the render function in the [Adding Pages Guide](adding_pages.html). Our `show` action in `web/controllers/hello_controller.ex` looked like this.
 
 ```elixir
 defmodule HelloPhoenix.HelloController do
@@ -264,7 +264,7 @@ Using Plug functions in this way, we can craft just the response we need.
 
 Rendering does not end with the template, though. By default, the results of the template render will be inserted into a layout, which will also be rendered.
 
-[Templates and layouts](http://www.phoenixframework.org/docs/templates) have their own guide, so we won't spend much time on them here. What we will look at is how to assign a different layout, or none at all, from inside a controller action.
+[Templates and layouts](templates.html) have their own guide, so we won't spend much time on them here. What we will look at is how to assign a different layout, or none at all, from inside a controller action.
 
 ### Assigning Layouts
 
@@ -510,7 +510,7 @@ def index(conn, _params) do
 end
 ```
 
-We can also make use of the path helpers we learned about in the [Routing Guide](http://www.phoenixframework.org/docs/routing). It's useful to `alias` the helpers in `web/router.ex` in order to shorten the expression.
+We can also make use of the path helpers we learned about in the [Routing Guide](routing.html). It's useful to `alias` the helpers in `web/router.ex` in order to shorten the expression.
 
 ```elixir
 defmodule HelloPhoenix.PageController do

--- a/docs/deployment/deployment.md
+++ b/docs/deployment/deployment.md
@@ -1,6 +1,6 @@
 # Introduction to Deployment
 
-Once we have a working application, we're ready to deploy it. If you're not quite finished with your own application, don't worry. Just follow the [Up and Running Guide](http://www.phoenixframework.org/docs/up-and-running) to create a basic application to work with.
+Once we have a working application, we're ready to deploy it. If you're not quite finished with your own application, don't worry. Just follow the [Up and Running Guide](up_and_running.html) to create a basic application to work with.
 
 When preparing an application for deployment, there are three main steps:
 
@@ -8,7 +8,7 @@ When preparing an application for deployment, there are three main steps:
   * Compiling your application assets
   * Starting your server in production
 
-How those are exactly handled depends on your deployment infrastructure. In particular, we have guides specific to [Heroku](http://www.phoenixframework.org/docs/heroku) and [an Advanced Deployment Guide](http://www.phoenixframework.org/docs/advanced-deployment) that uses Erlang style releases. In any case, this chapter provides a general overview of the deployment steps, which will be useful regardless of your infrastructure or if you want to run in production locally.
+How those are exactly handled depends on your deployment infrastructure. In particular, we have guides specific to [Heroku](heroku.html) and [an Advanced Deployment Guide](exrm_releases.html) that uses Erlang style releases. In any case, this chapter provides a general overview of the deployment steps, which will be useful regardless of your infrastructure or if you want to run in production locally.
 
 Let's explore those steps above one by one.
 
@@ -42,7 +42,7 @@ config :foo, Foo.Repo,
   size: 20 # The amount of database connections in the pool
 ```
 
-There are different ways to get this data into production. One option is to replace the data above by environment variables and set those environment variables in your production machine. This is the step that we follow [in the Heroku guides](http://www.phoenixframework.org/docs/heroku).
+There are different ways to get this data into production. One option is to replace the data above by environment variables and set those environment variables in your production machine. This is the step that we follow [in the Heroku guides](heroku.html).
 
 Another approach is to configure the file above and place it in your production machines apart from your code checkout, for example, at "/var/config.prod.exs". After doing so, you will have to import it from `config/prod.exs`. Search for the `import_config` line and replace it by the proper path:
 

--- a/docs/ecto_models.md
+++ b/docs/ecto_models.md
@@ -10,11 +10,11 @@ Most web applications today need some form of data storage. In the Elixir ecosys
 
 Newly generated Phoenix applications integrate both Ecto and the PostgreSQL adapter by default.
 
-For a thorough, general guide for Ecto, check out the [Ecto getting started guide](https://hexdocs.pm/ecto/getting-started.html). For an overview of all Ecto specific mix tasks for Phoenix, see the [mix tasks guide](http://www.phoenixframework.org/docs/mix-tasks#section-ecto-specific-mix-tasks).
+For a thorough, general guide for Ecto, check out the [Ecto getting started guide](https://hexdocs.pm/ecto/getting-started.html). For an overview of all Ecto specific mix tasks for Phoenix, see the [mix tasks guide](mix_tasks.html#ecto-specific-mix-tasks).
 
 This guide assumes that we have generated our new application with Ecto. If we're using an older Phoenix app, or we used the `--no-ecto` option to generate our application, all is not lost. Please follow the instructions in the "Integrating Ecto into an Existing Application" section below.
 
-This guide also assumes that we will be using PostgreSQL. For instructions on switching to MySQL, please see the [Using MySQL Guide](http://www.phoenixframework.org/docs/using-mysql).
+This guide also assumes that we will be using PostgreSQL. For instructions on switching to MySQL, please see the [Using MySQL Guide](using_mysql.html).
 
 The default Postgres configuration has a superuser account with username 'postgres' and the password 'postgres'. If you take a look at the file ```config/dev.exs```, you'll see that Phoenix works off this assumption. If you don't have this account already setup on your machine, you can connect to your postgres instance by typing ```psql``` and enter the following commands:
 
@@ -707,7 +707,7 @@ defmodule HelloPhoenix do
 end
 ```
 
-Now that Ecto is configured, we can use the [mix tasks](http://www.phoenixframework.org/docs/mix-tasks#section--mix-phoenix-gen-model-) to generate models. By default all model files should have the line `use HelloPhoenix.Web, :model` which handles the imports, but does not yet contain the `Ecto` dependencies. We can define or append the `model` function in the `web/web.ex` file:
+Now that Ecto is configured, we can use the [mix tasks](mix_tasks.html#phoenix-specific-mix-tasks) to generate models. By default all model files should have the line `use HelloPhoenix.Web, :model` which handles the imports, but does not yet contain the `Ecto` dependencies. We can define or append the `model` function in the `web/web.ex` file:
 
 ```elixir
   def model do

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-In the [Overview Guide](http://www.phoenixframework.org/docs/overview) we got a look at the Phoenix ecosystem and how the pieces interrelate. Now it's time to install any software we might need before we jump into the [Up and Running Guide](http://www.phoenixframework.org/docs/up-and-running).
+In the [Overview Guide](overview.html) we got a look at the Phoenix ecosystem and how the pieces interrelate. Now it's time to install any software we might need before we jump into the [Up and Running Guide](up_and_running.html).
 
 Please take a look at this list and make sure to install anything necessary for your system. Having dependencies installed in advance can prevent frustrating problems later on.
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -181,7 +181,7 @@ This is significant because we can use the `page_path` function in a template to
 ```html
 <a href="<%= page_path(@conn, :index) %>">To the Welcome Page!</a>
 ```
-Please see the [View Guide](http://www.phoenixframework.org/docs/views) for more information.
+Please see the [View Guide](views.html) for more information.
 
 This pays off tremendously if we should ever have to change the path of our route in the router. Since the path helpers are built dynamically from the routes, any calls to `page_path` in our templates will still work.
 
@@ -595,7 +595,7 @@ post_path  DELETE  /posts/:id       AnotherApp.PostController :delete
 
 We have come quite a long way in this guide without talking about one of the first lines we saw in the router - `pipe_through :browser`. It's time to fix that.
 
-Remember in the [Overview Guide](http://www.phoenixframework.org/docs/overview) when we described plugs as being stacked and executable in a pre-determined order, like a pipeline? Now we're going to take a closer look at how these plug stacks work in the router.
+Remember in the [Overview Guide](overview.html) when we described plugs as being stacked and executable in a pre-determined order, like a pipeline? Now we're going to take a closer look at how these plug stacks work in the router.
 
 Pipelines are simply plugs stacked up together in a specific order and given a name. They allow us to customize behaviors and transformations related to the handling of requests. Phoenix provides us with some default pipelines for a number of common tasks. In turn we can customize them as well as create new pipelines to meet our needs.
 
@@ -785,7 +785,7 @@ end
 
 ### Channel Routes
 
-Channels are a very exciting, real-time component of the Phoenix framework. Channels handle incoming and outgoing messages broadcast over a socket for a given topic. Channel routes, then, need to match requests by socket and topic in order to dispatch to the correct channel. (For a more detailed description of channels and their behavior, please see the [Channel Guide](http://www.phoenixframework.org/docs/channels).)
+Channels are a very exciting, real-time component of the Phoenix framework. Channels handle incoming and outgoing messages broadcast over a socket for a given topic. Channel routes, then, need to match requests by socket and topic in order to dispatch to the correct channel. (For a more detailed description of channels and their behavior, please see the [Channel Guide](channels.html).)
 
 We mount socket handlers in our endpoint at `lib/hello_phoenix/endpoint.ex`. Socket handlers take care of authentication callbacks and channel routes.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -4,11 +4,11 @@ Templates are what they sound like they should be: files into which we pass data
 
 EEx is the default template system in Phoenix, and it is quite similar to ERB in Ruby. It is actually part of Elixir itself, and Phoenix uses EEx templates to create files like the router and the main application view while generating a new application.
 
-As we learned in the [View Guide](http://www.phoenixframework.org/docs/views), by default, templates live in the `web/templates` directory, organized into directories named after a view. Each directory has its own view module to render the templates in it.
+As we learned in the [View Guide](views.html), by default, templates live in the `web/templates` directory, organized into directories named after a view. Each directory has its own view module to render the templates in it.
 
 ### Examples
 
-We've already seen several ways in which templates are used, notably in the [Adding Pages Guide](http://www.phoenixframework.org/docs/adding-pages) and the [Views Guide](http://www.phoenixframework.org/docs/views). We may cover some of the same territory here, but we will certainly add some new information.
+We've already seen several ways in which templates are used, notably in the [Adding Pages Guide](adding_pages.html) and the [Views Guide](views.html). We may cover some of the same territory here, but we will certainly add some new information.
 
 ##### web.ex
 

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -8,9 +8,9 @@ ExUnit refers to a test module as a "test case", and we will do the same.
 
 Let's see this in action.
 
-> Note: Before we proceed, we'll need to have PostgreSQL installed and running on our system. We'll also need to configure our repo with the correct login credentials. [The section on ecto.create in the Mix Tasks guide](http://www.phoenixframework.org/docs/mix-tasks#section--ecto-create-) has more information on this, and the [Ecto Models Guide](http://www.phoenixframework.org/docs/ecto-models) dives into the details on how it all works.
+> Note: Before we proceed, we'll need to have PostgreSQL installed and running on our system. We'll also need to configure our repo with the correct login credentials. [The section on ecto.create in the Mix Tasks guide](mix_tasks.html#ecto-specific-mix-tasks) has more information on this, and the [Ecto Models Guide](ecto_models.html) dives into the details on how it all works.
 
-In a freshly generated application, let's run `mix test` at the root of the project. (Please see the [Up and Running Guide](http://www.phoenixframework.org/docs/up-and-running) for instructions on generating a new application.)
+In a freshly generated application, let's run `mix test` at the root of the project. (Please see the [Up and Running Guide](up_and_running.html) for instructions on generating a new application.)
 
 ```console
 $ mix test
@@ -450,7 +450,7 @@ Randomized with seed 401472
 
 We've seen what Phoenix gives us with a newly generated app. Now let's see what happens when we generate a new HTML resource.
 
-Let's borrow the `users` resource we created in the [Ecto Models Guide](http://www.phoenixframework.org/docs/ecto-models).
+Let's borrow the `users` resource we created in the [Ecto Models Guide](ecto_models.html).
 
 At the root of our new application, let's run the `mix phoenix.gen.html` task with the following options.
 

--- a/docs/testing/testing_controllers.md
+++ b/docs/testing/testing_controllers.md
@@ -11,7 +11,7 @@ mix phoenix.gen.json Thing things some_attr:string another_attr:string
 
 Thing is the Model, things is the table name, and some_attr and another_attr are database columns on table things of type string. Don't run this command, we're going to explore test driving out a similar result to what a generator would give us.
 
-Let's create a `User` model. Since model creation is not in scope of this guide, we will use the generator.  If you aren't familiar, read [this section of the Mix guide](http://www.phoenixframework.org/docs/mix-tasks#section--mix-phoenix-gen-model-).
+Let's create a `User` model. Since model creation is not in scope of this guide, we will use the generator.  If you aren't familiar, read [this section of the Mix guide](mix_tasks.html#phoenix-specific-mix-tasks).
 
 ```bash
 $ mix phoenix.gen.model User users name:string email:string

--- a/docs/testing/testing_models.md
+++ b/docs/testing/testing_models.md
@@ -1,6 +1,6 @@
 # Testing Models
 
-In the [Ecto Models Guide](http://www.phoenixframework.org/docs/ecto-models) we generated an HTML resource for users. This gave us a number of modules for free, including a user model and a user model test case. In this guide, we'll use the model and test case to work through the changes we made in the Ecto Models Guide in a test-driven way.
+In the [Ecto Models Guide](ecto_models.html) we generated an HTML resource for users. This gave us a number of modules for free, including a user model and a user model test case. In this guide, we'll use the model and test case to work through the changes we made in the Ecto Models Guide in a test-driven way.
 
 For those of us who haven't worked through the Ecto Models Guide, it's easy to catch up. Please see the "Generating an HTML Resource" section below.
 
@@ -426,7 +426,7 @@ Randomized with seed 330955
 
 For this section, we're going to assume that we all have a PostgreSQL database installed on our system, and that we generated a default application - one in which Ecto and Postgrex are installed and configured automatically.
 
-If this is not the case, please see the section on adding Ecto and Postgrex of the [Ecto Models Guide](http://www.phoenixframework.org/docs/ecto-models#section-adding-ecto-and-postgrex-as-dependencies) and join us when that's done.
+If this is not the case, please see the section on adding Ecto and Postgrex of the [Ecto Models Guide](ecto_models.html) and join us when that's done.
 
 Ok, once we're all configured properly, we need to run the `phoenix.gen.html` task with the list of attributes we have here.
 

--- a/docs/up_and_running.md
+++ b/docs/up_and_running.md
@@ -2,7 +2,7 @@
 
 The aim of this first guide is to get a Phoenix application up and running as quickly as possible.
 
-Before we begin, please take a minute to read the [Installation Guide](http://www.phoenixframework.org/docs/installation). By installing any necessary dependencies beforehand, we'll be able to get our application up and running smoothly.
+Before we begin, please take a minute to read the [Installation Guide](installation.html). By installing any necessary dependencies beforehand, we'll be able to get our application up and running smoothly.
 
 At this point, we should have Elixir, Erlang, Hex, and the Phoenix archive installed. We should also have PostgreSQL and node.js installed to build a default application.
 
@@ -57,7 +57,7 @@ Before moving on, configure your database in config/dev.exs and run:
 
 Once our dependencies are installed, the task will prompt us to change into our project directory and start our application.
 
-Phoenix assumes that our PostgreSQL database will have a `postgres` user account with the correct permissions and a password of "postgres". If that isn't the case, please see the instructions for the [ecto.create](http://www.phoenixframework.org/docs/mix-tasks#section--ecto-create-) mix task.
+Phoenix assumes that our PostgreSQL database will have a `postgres` user account with the correct permissions and a password of "postgres". If that isn't the case, please see the instructions for the [ecto.create](mix_tasks.html#ecto-specific-mix-tasks) mix task.
 
 Ok, let's give it a try. First, we'll `cd` into the `hello_phoenix/` directory we've just created:
 

--- a/docs/views.md
+++ b/docs/views.md
@@ -166,7 +166,7 @@ If we look at `web/templates/layout/app.html.eex`, just about in the middle of t
 
 This is where the view module and its template from the controller are rendered to a string and placed in the layout.
 
-### The ErrorView
+## The ErrorView
 
 Phoenix has a view called the `ErrorView` which lives in `web/views/error_view.ex`. The purpose of the `ErrorView` is to handle two of the most common errors - `404 not found` and `500 internal error` - in a general way, from one centralized location. Let's see what it looks like.
 


### PR DESCRIPTION
All URLs that previously referenced http://phoenixframework.org for the
pages will no longer be valid when the guides are merged with the
Phoenix repository.