### PR TITLE
Add mix docs.watch task for watching markdown files

### DIFF
--- a/lib/mix/tasks/docs.watch.ex
+++ b/lib/mix/tasks/docs.watch.ex
@@ -1,0 +1,43 @@
+defmodule PhoenixGuides.Watcher do
+  use GenServer
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, :ignored)
+  end
+
+  def init(_) do
+    :ok = Application.ensure_started(:fs)
+    :ok = :fs.subscribe()
+    docs_path = File.cwd!() <> "/docs"
+    {:ok, %{docs_path: docs_path}}
+  end
+
+  def handle_info({_pid, {:fs, :file_event}, {path, _event}}, %{docs_path: docs_path} = state) do
+    path = to_string(path)
+    if String.contains?(path, docs_path) do
+      IO.puts "#{path} changed. Rebuilding docs."
+      Mix.Task.rerun("docs")
+    end
+    {:noreply, state}
+  end
+
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+end
+
+defmodule Mix.Tasks.Docs.Watch do
+  use Mix.Task
+
+  @moduledoc """
+  A task for building the docs whenever files change
+  """
+  @shortdoc "Automatically build docs on file changes"
+
+  def run(_args) do
+    PhoenixGuides.Watcher.start_link()
+    unless Code.ensure_loaded?(IEx) && IEx.started? do
+      :timer.sleep(:infinity)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule PhoenixGuides.Mixfile do
      version: @version,
      elixir: "~> 1.3",
      deps: deps(),
+     preferred_cli_env: ["docs.watch": :docs, docs: :docs],
      docs: [source_ref: "v#{@version}",
             main: "overview",
             logo: "styling/Phoenix_files/phoenix-logo-white.png",
@@ -26,7 +27,8 @@ defmodule PhoenixGuides.Mixfile do
   end
 
   defp deps do
-    [{:ex_doc, "~> 0.14", only: :docs}]
+    [{:ex_doc, "~> 0.14", only: :docs},
+     {:fs, "~> 0.9.1", only: :docs}]
   end
 
   defp extras do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []}}


### PR DESCRIPTION
`mix docs.watch` will watch for changes, and if any files in the `docs`
directory change, the `mix docs` task will be executed, regenerating the
documentation.