### PR TITLE
Add app name to the `Email` Module name.

### DIFF
--- a/docs/bonus_guides/sending_email_with_smtp.md
+++ b/docs/bonus_guides/sending_email_with_smtp.md
@@ -96,10 +96,10 @@ end
 ```
 
 Lastly we need another module that will contain our emails, which we can
-define in `lib/email.ex`.
+define in `lib/my_app/email.ex`.
 
 ```elixir
-defmodule Email do
+defmodule MyApp.Email do
   use Bamboo.Phoenix, view: MyApp.EmailView
 end
 ```


### PR DESCRIPTION
I believe this may have been a typo? If not then please ignore this PR