### PR TITLE
Fix formatting of text blocks

### DIFF
--- a/docs/adding_pages.md
+++ b/docs/adding_pages.md
@@ -4,7 +4,7 @@ Our task for this guide is to add two new pages to our Phoenix application. One 
 
 When Phoenix generates a new application for us, it builds a top-level directory structure like this:
 
-```text
+```console
 ├── _build
 ├── config
 ├── deps
@@ -16,29 +16,29 @@ When Phoenix generates a new application for us, it builds a top-level directory
 
 Most of our work in this guide will be in the `web` directory, which looks like this when expanded:
 
-```text
+```console
 ├── channels
-    └── user_socket.ex
+│   └── user_socket.ex
 ├── controllers
-│   └── page_controller.ex
+│   └── page_controller.ex
 ├── models
 ├── static
-│   ├── assets
-│   |   ├── images
-|   |   |   └── phoenix.png
-|   |   └── favicon.ico
-|   |   └── robots.txt
-│   |   ├── vendor
+│   ├── assets
+│   │   ├── images
+│   │   │   └── phoenix.png
+│   │   └── favicon.ico
+│   │   └── robots.txt
+│   │   ├── vendor
 ├── templates
-│   ├── layout
-│   │   └── app.html.eex
-│   └── page
-│       └── index.html.eex
+│   ├── layout
+│   │   └── app.html.eex
+│   └── page
+│       └── index.html.eex
 └── views
-|   ├── error_helpers.ex
-|   ├── error_view.ex
-|   ├── layout_view.ex
-|   └── page_view.ex
+│   ├── error_helpers.ex
+│   ├── error_view.ex
+│   ├── layout_view.ex
+│   └── page_view.ex
 ├── router.ex
 ├── gettext.ex
 ├── web.ex
@@ -48,31 +48,31 @@ All of the files which are currently in the `controllers`, `templates`, and `vie
 
 All of our application's static assets live in `priv/static` in the directory appropriate for each type of file - css, images or js. We place assets that require a build phase into `web/static`, and the source files are built into their respective `app.js` / `app.css` bundles within `priv/static`. We won't be making any changes here for now, but it is good to know where to look for future reference.
 
-```text
+```console
 priv
-└── static
+└── static 
     └── images
         └── phoenix.png
 ```
 
-```text
+```console
 web
 └── static
     ├── assets
-    |   ├── css
-    |   |   └── app.css
-    |   ├── js
-    |   │   └── app.js
-    |   └── vendor
+    │   ├── css
+    │   │   └── app.css
+    │   ├── js
+    │   │   └── app.js
+    │   └── vendor
 ```
 
 The `lib` directory also contains files we should know about. Our application's endpoint is at `lib/hello_phoenix/endpoint.ex`, and our application file (which starts our application and its supervision tree) is at `lib/hello_phoenix.ex`.
 
-```text
+```console
 lib
 ├── hello_phoenix
-|   ├── endpoint.ex
-│   └── repo.ex
+│   ├── endpoint.ex
+│   └── repo.ex
 └── hello_phoenix.ex
 ```
 

--- a/docs/bonus_guides/mix_tasks.md
+++ b/docs/bonus_guides/mix_tasks.md
@@ -446,7 +446,7 @@ Before we run this task let's inspect the contents of two directories in our hel
 
 First `priv/static` which should look similar to this:
 
-```text
+```console
 ├── images
 │   └── phoenix.png
 ├── robots.txt
@@ -454,7 +454,7 @@ First `priv/static` which should look similar to this:
 
 And then `web/static/` which should look similar to this:
 
-```text
+```console
 ├── css
 │   └── app.css
 ├── js

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -291,7 +291,7 @@ Very Important! For function calls in the middle of a pipeline, like `put_layout
 
 If you ever get a stack trace that looks like this,
 
-```text
+```console
 **(FunctionClauseError) no function clause matching in Plug.Conn.get_resp_header/2
 
 Stacktrace

--- a/docs/deployment/exrm_releases.md
+++ b/docs/deployment/exrm_releases.md
@@ -408,7 +408,7 @@ First step in exposing our application to the world is ensuring that our applica
 
 Let's use `upstart` as an example. We'll edit our init script with `sudo vi /etc/init/hello_phoenix.conf` (this is on Ubuntu Linux).
 
-```text
+```console
 description "hello_phoenix"
 
 ## Uncomment the following two lines to run the

--- a/docs/ecto_models.md
+++ b/docs/ecto_models.md
@@ -358,7 +358,7 @@ What if we had a requirement that all biographies in our system must be at least
 
 Now if we try to add a new user through the front end of the application with a bio of "A", we should see this error message at the top of the page.
 
-```text
+```console
 Oops, something went wrong! Please check the errors below:
 Bio should be at least 2 characters
 ```
@@ -377,7 +377,7 @@ If we also have a requirement for the maximum length that a bio can have, we can
 
 Now if we try to add a new user with a 141 character bio, we would see this error.
 
-```text
+```console
 Oops, something went wrong! Please check the errors below:
 Bio should be at most 140 characters
 ```
@@ -397,7 +397,7 @@ Let's say we want to perform at least some rudimentary format validation on the 
 
 If we try to create a user with an email of "personexample.com", we should see an error message like the following.
 
-```text
+```console
 Oops, something went wrong! Please check the errors below:
 Email has invalid format
 ```

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -70,7 +70,7 @@ get "/", RootController, :index
 
 Then run `$ mix compile` at the root of your project. You will see the following warning from the compiler:
 
-```text
+```console
 web/router.ex:1: warning: this clause cannot match because a previous clause at line 1 always matches
 Compiled web/router.ex
 ```
@@ -277,7 +277,7 @@ Scopes are a way to group routes under a common path prefix and scoped set of pl
 
 The paths to the user facing reviews would look like a standard resource.
 
-```text
+```console
 /reviews
 /reviews/1234
 /reviews/1234/edit
@@ -286,7 +286,7 @@ The paths to the user facing reviews would look like a standard resource.
 
 The admin review paths could be prefixed with `/admin`.
 
-```text
+```console
 /admin/reviews
 /admin/reviews/1234
 /admin/reviews/1234/edit

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -32,12 +32,12 @@ In fact, we already have a directory structure completely set up for testing, in
 test
 ├── channels
 ├── controllers
-│   └── page_controller_test.exs
+│   └── page_controller_test.exs
 ├── models
 ├── support
-│   ├── channel_case.ex
-│   ├── conn_case.ex
-│   └── model_case.ex
+│   ├── channel_case.ex
+│   ├── conn_case.ex
+│   └── model_case.ex
 ├── test_helper.exs
 └── views
     ├── error_view_test.exs


### PR DESCRIPTION
For whatever reason \`\`\`text blocks revert to single-line mode. Changing  to \`\`\`console fixes it.

Also, mixed character types in directory trees causes the formatter  to revert to single-line mode (Apparently these are different: |│)