### PR TITLE
Update Phoenix buildpack to use Node 6 LTS

### DIFF
--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -74,13 +74,13 @@ The URL in the output is the URL to our application. If we open it in our browse
 
 ## Adding the Phoenix Static Buildpack
 
-We need to compile static assets for a successful Phoenix deployment. The [Phoenix static buildpack](https://github.com/gjaldon/heroku-buildpack-phoenix-static) can take care of that for us, so let's add it now.
+We need to compile static assets for a successful Phoenix deployment. The [Phoenix static buildpack](https://github.com/acconrad/heroku-buildpack-phoenix-static) can take care of that for us, so let's add it now.
 
 ```console
-$ heroku buildpacks:add https://github.com/gjaldon/heroku-buildpack-phoenix-static.git
+$ heroku buildpacks:add https://github.com/acconrad/heroku-buildpack-phoenix-static.git
 Buildpack added. Next release on mysterious-meadow-6277 will use:
   1. https://github.com/HashNuke/heroku-buildpack-elixir.git
-  2. https://github.com/gjaldon/heroku-buildpack-phoenix-static.git
+  2. https://github.com/acconrad/heroku-buildpack-phoenix-static.git
 Run `git push heroku master` to create a new release using these buildpacks.
 ```
 


### PR DESCRIPTION
@gjaldon 's version of the Phoenix buildpack uses Node 5, which is significantly behind the stable LTS version of Node. It also utilizes NPM 2, which is a nested, resource-intensive version of NPM that can cause memory issues and extremely bloated apps.

I have forked that buildpack to use Node LTS (6.9.2) by default. Using LTS is more stable and easier to debug against the Node community, but more importantly, it relies upon NPM 3 instead of NPM 2, which utilizes a much flatter, much smaller dependency management system.