### PR TITLE
Postgres Installation: Note about default encoding

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -80,6 +80,8 @@ $ ln -s /usr/bin/nodejs /usr/bin/node
 PostgreSQL is a relational database server. Phoenix configures applications to use it by default, but we can switch to MySQL by passing the `--database mysql` flag when creating a new application.
 
 When we work with Ecto models in these guides, we will use PostgreSQL and the Postgrex adapter for it. In order to follow along with the examples, we should install PostgreSQL. The PostgreSQL wiki has [installation guides](https://wiki.postgresql.org/wiki/Detailed_installation_guides) for a number of different systems.
+> Note: In OSX, if you had installed postgres via homebrew, your default encoding might be SQL ASCII and not UTF-8. This might cause the `ERROR:  new encoding (UTF8) is incompatible with the encoding of the template database (SQL_ASCII)` when connecting to the database through the application. To fix this, you should create the DB in postgres with the `-E` option: `/usr/local/pgsql/bin/initdb -E UTF8 -D /usr/local/pgsql/data -U postgres`
+
 
 Postgrex is a direct Phoenix dependency, and it will be automatically installed along with the rest of our dependencies as we start our app.
 


### PR DESCRIPTION
On OSX, when Postgres is installed using brew, the default encoding is set to SQL ASCII as explained https://www.postgresql.org/docs/current/static/app-initdb.html. This caused an error when doing `mix ecto.create` in the Up and Running section. Creating Postgres DB with the UTF-8 fixes this problem. 

I believe this "note" is needed because people who are new to Postgres and starting up with Elixir and Phoenix might think this is a Phoneix/Elixir/Erlang issue and not necessarily Postgres issue.