### PR TITLE
more clear controllers.md

### DIFF
--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -218,7 +218,7 @@ plug :assign_welcome_message, "Welcome Back"
 
 def index(conn, _params) do
   conn
-  |> assign(:name, "Dweezil")
+  |> assign(:message, "Welcome Forward")
   |> render("index.html")
 end
 


### PR DESCRIPTION
The present example does not show the plug's welcome message being
overridden like it says so in the text. This new example more clearly
matches the text.