### PR TITLE
clarified misleading sentence in ecto_models.md

### DIFF
--- a/docs/ecto_models.md
+++ b/docs/ecto_models.md
@@ -248,7 +248,7 @@ Let's take a closer look at our default changeset.
   end
 ```
 Right now, we have two transformations in our pipeline to this model.
-In the first call, we invoke `cast/3` to send in our parameters and which fields are required for validation.
+In the first call, we invoke `cast/3` to send in our parameters and which fields are whitelisted for validation.
 `cast/3` first takes a struct, then the parameters (the proposed updates), and then the final field is the list of columns to be updated.
 `cast/3` also will only take fields that exist in the schema.
 Next, `validate_required/3` checks that this list of fields is present in the changeset that `cast/3` returns.


### PR DESCRIPTION
cast/3's third argument is the allowed fields, not the required ones.