### PR TITLE
update link to HTTP code mapping

### DIFF
--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -420,7 +420,7 @@ For a list of valid content mime-types, please see the [mime.types](https://gith
 
 We can also set the HTTP status code of a response similarly to the way we set the content type. The `Plug.Conn` module, imported into all controllers, has a `put_status/2` function to do this.
 
-`put_status/2` takes `conn` as the first parameter and as the second parameter either an integer or a "friendly name" used as an atom for the status code we want to set. Here is the list of supported [friendly names](https://github.com/elixir-lang/plug/blob/master/lib/plug/conn/status.ex#L7-L66).
+`put_status/2` takes `conn` as the first parameter and as the second parameter either an integer or a "friendly name" used as an atom for the status code we want to set. Here is the list of supported [friendly names](https://github.com/elixir-lang/plug/blob/master/lib/plug/conn/status.ex#L9-L69).
 
 Let's change the status in our `PageController` `index` action.
 


### PR DESCRIPTION
Currently, the link to HTTP code mappings is highlighting incorrectly. This fix adjusts the highlighted line numbers.

### Before
![before](https://cloud.githubusercontent.com/assets/2787/23624014/2ec1ebc6-0272-11e7-94fc-5ada742e939c.png)
### After
![after](https://cloud.githubusercontent.com/assets/2787/23624020/3169590e-0272-11e7-8e14-921d1957db23.png)
