### PR TITLE
Small improvements to the Ecto models guide

### DIFF
--- a/docs/ecto_models.md
+++ b/docs/ecto_models.md
@@ -12,7 +12,7 @@ Newly generated Phoenix applications integrate both Ecto and the PostgreSQL adap
 
 For a thorough, general guide for Ecto, check out the [Ecto getting started guide](https://hexdocs.pm/ecto/getting-started.html). For an overview of all Ecto specific mix tasks for Phoenix, see the [mix tasks guide](mix_tasks.html#ecto-specific-mix-tasks).
 
-This guide assumes that we have generated our new application with Ecto. If we're using an older Phoenix app, or we used the `--no-ecto` option to generate our application, all is not lost. Please follow the instructions in the [Integrating Ecto into an Existing Application](integrating-ecto-into-an-existing-application) section below.
+This guide assumes that we have generated our new application with Ecto. If we're using an older Phoenix app, or we used the `--no-ecto` option to generate our application, all is not lost. Please follow the instructions in the [Integrating Ecto into an Existing Application](#integrating-ecto-into-an-existing-application) section below.
 
 This guide also assumes that we will be using PostgreSQL. For instructions on switching to MySQL, please see the [Using MySQL Guide](using_mysql.html).
 

--- a/docs/ecto_models.md
+++ b/docs/ecto_models.md
@@ -12,7 +12,7 @@ Newly generated Phoenix applications integrate both Ecto and the PostgreSQL adap
 
 For a thorough, general guide for Ecto, check out the [Ecto getting started guide](https://hexdocs.pm/ecto/getting-started.html). For an overview of all Ecto specific mix tasks for Phoenix, see the [mix tasks guide](mix_tasks.html#ecto-specific-mix-tasks).
 
-This guide assumes that we have generated our new application with Ecto. If we're using an older Phoenix app, or we used the `--no-ecto` option to generate our application, all is not lost. Please follow the instructions in the "Integrating Ecto into an Existing Application" section below.
+This guide assumes that we have generated our new application with Ecto. If we're using an older Phoenix app, or we used the `--no-ecto` option to generate our application, all is not lost. Please follow the instructions in the [Integrating Ecto into an Existing Application](integrating-ecto-into-an-existing-application) section below.
 
 This guide also assumes that we will be using PostgreSQL. For instructions on switching to MySQL, please see the [Using MySQL Guide](using_mysql.html).
 
@@ -648,7 +648,7 @@ Dependency resolution completed successfully
 The next piece we need to add is our application's repo. We can easily do that with the `ecto.gen.repo -r HelloPhoenix.Repo` task. 
 
 ```console
-$ mix ecto.gen.repo
+$ mix ecto.gen.repo -r HelloPhoenix.Repo
 * creating lib/hello_phoenix
 * creating lib/hello_phoenix/repo.ex
 * updating config/config.exs


### PR DESCRIPTION
Adds:

- one internal link (not sure if link will work on the phoenix web site)
- missing parameter in the `mix ecto.gen.repo` command