### PR TITLE
Add note to Heroku deploy guide about static asset buildpack

### DIFF
--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -76,6 +76,8 @@ The URL in the output is the URL to our application. If we open it in our browse
 
 We need to compile static assets for a successful Phoenix deployment. The [Phoenix static buildpack](https://github.com/gjaldon/heroku-buildpack-phoenix-static) can take care of that for us, so let's add it now.
 
+_Skip this step if you do not have any static assets (i.e. you created your project with the `--no-brunch --no-html` flags)._
+
 ```console
 $ heroku buildpacks:add https://github.com/gjaldon/heroku-buildpack-phoenix-static.git
 Buildpack added. Next release on mysterious-meadow-6277 will use:


### PR DESCRIPTION
Mention that the entire "Adding The Phoenix Static Buildpack" section can be skipped for API only applications in the "Heroku" guide.

The app will fail to compile and deploy if it has the static buildpack without static assets.

This will be helpful for beginners.