### PR TITLE
Removing note for importing Router.Helpers

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -184,7 +184,8 @@ This is significant because we can use the `page_path` function in a template to
 ```html
 <a href="<%= page_path(@conn, :index) %>">To the Welcome Page!</a>
 ```
-Please see the [View Guide](views.html) for more information.
+
+The `page_path` function is imported into our template with `use HelloPhoenix.Web, :view`. Please see the [View Guide](views.html) for more information.
 
 This pays off tremendously if we should ever have to change the path of our route in the router. Since the path helpers are built dynamically from the routes, any calls to `page_path` in our templates will still work.
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -179,7 +179,7 @@ iex> HelloPhoenix.Router.Helpers.page_path(HelloPhoenix.Endpoint, :index)
 "/"
 ```
 
-This is significant because we can use the `page_path` function in a template to link to the root of our application. Note: If that function invocation seems uncomfortably long, there is a solution, including `import HelloPhoenix.Router.Helpers` in our main application view.
+This is significant because we can use the `page_path` function in a template to link to the root of our application. We can then use this helper in our templates:
 
 ```html
 <a href="<%= page_path(@conn, :index) %>">To the Welcome Page!</a>


### PR DESCRIPTION
As I was running through the guide, as a first time user, I expected that I needed to add  `import HelloPhoenix.Router.Helpers` to the application view. But I didn't have to, so this line might be a bit confusing if you're following along.