### PR TITLE
Fix Nginx config comment

### DIFF
--- a/docs/bonus_guides/phoenix_behind_proxy.md
+++ b/docs/bonus_guides/phoenix_behind_proxy.md
@@ -55,7 +55,7 @@ Thankfully, this is relatively straightforward to accomplish with nginx.
 Below is a standard `sites-enabled` style nginx configuration, for a given domain `my-app.domain`.
 
 ```
-// /etc/nginx/sites-enabled/my-app.domain
+# /etc/nginx/sites-enabled/my-app.domain
 upstream phoenix {
   server 127.0.0.1:4000 max_fails=5 fail_timeout=60s;
 }


### PR DESCRIPTION
Comment on first line of Nginx config breaks Nginx if copied without changes.
It must start from `#`.