### PR TITLE
Recommend an easier install of Postgres for Mac users

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -89,7 +89,9 @@ PostgreSQL is a relational database server. Phoenix configures applications to u
 
 When we work with Ecto models in these guides, we will use PostgreSQL and the Postgrex adapter for it. In order to follow along with the examples, we should install PostgreSQL. The PostgreSQL wiki has [installation guides](https://wiki.postgresql.org/wiki/Detailed_installation_guides) for a number of different systems.
 
-Postgrex is a direct Phoenix dependency, and it will be automatically installed along with the rest of our dependencies as we start our app.
+Postgres is a direct Phoenix dependency, and it will be automatically installed along with the rest of our dependencies as we start our app.
+
+If you are using a Mac OS, one of the easiest ways to integrate Postgres is with the [Postgres App](https://postgresapp.com/). Please read the instructions on their site for more details about system requirements.
 
 ### inotify-tools (for linux users)
 


### PR DESCRIPTION
I wanted to add an easier install of Postgres for Mac users with the Postgres App, a Postgres Mac GUI. This seemed to be the easiest way to get up and running with Postgres on my computer. I saw in other forums people were having dificulty with this as well, that's how I found Postgres App. Hopefully this can help others too.

I also fixed a type on line 92 where is said Postgrex.