### PR TITLE
Add Heroku limitations section. Resolves #701.

### DIFF
--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -10,7 +10,7 @@ Our main goal for this guide is to get a Phoenix application running on Heroku.
 
 ### Limitations
 
-Heroku is a great platform overall, but for Elixir apps, it comes with a number of limitations you should be aware of. 
+Heroku is a great platform and Elixir performs well on it. However, you may run into limitations if you plan to leverage advanced features provided by Elixir and Phoenix, such as:
 
 - Connections are limited.
     - Heroku [limits the number of simultaneous connections](https://devcenter.heroku.com/articles/http-routing#request-concurrency) as well as the [duration of each connection](https://devcenter.heroku.com/articles/limits#http-timeouts). It is common to use Elixir for real-time apps which need lots of concurrent, persistent connections, and Phoenix is capable of [handling over 2 million connections on a single server](http://www.phoenixframework.org/blog/the-road-to-2-million-websocket-connections).
@@ -24,10 +24,9 @@ Heroku is a great platform overall, but for Elixir apps, it comes with a number 
 - [Remote shells](https://hexdocs.pm/iex/IEx.html#module-remote-shells) and remote observer are not possible. 
     - Heroku does not allow SSH access to your dynos so you can not inspect, debug, or trace your production nodes using things like [the built-in Observer](https://elixir-lang.org/getting-started/mix-otp/supervisor-and-application.html#observer).
 
-- Hot upgrades are not possible. 
-    - Heroku deployments always replace dynos so websocket connections, running processes, etc will be lost on every deploy.
-
-If you're looking for a platform without these limitations, [Gigalixir](https://www.gigalixir.com/) is an Elixir-only PaaS, very similar to Heroku, designed to solve these problems.
+If you are just getting started or you don't expect to use the features above, Heroku should be enough for your needs. For instance, if you are migrating an existing application running on Heroku to Phoenix, keeping a similar set of features, Elixir will perform just as well or even better then your current stack.
+ 
+If you want a platform-as-a-service without these limitations, try [Gigalixir](http://gigalixir.readthedocs.io/). If you don't want a PaaS, try [Distillery](https://github.com/bitwalker/distillery).
 
 ## Steps
 

--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -8,6 +8,27 @@ The only thing we'll need for this guide is a working Phoenix application. For t
 
 Our main goal for this guide is to get a Phoenix application running on Heroku.
 
+### Limitations
+
+Heroku is a great platform overall, but for Elixir apps, it comes with a number of limitations you should be aware of. 
+
+- Connections are limited.
+    - Heroku [limits the number of simultaneous connections](https://devcenter.heroku.com/articles/http-routing#request-concurrency) as well as the [duration of each connection](https://devcenter.heroku.com/articles/limits#http-timeouts). It is common to use Elixir for real-time apps which need lots of concurrent, persistent connections, and Phoenix is capable of [handling over 2 million connections on a single server](http://www.phoenixframework.org/blog/the-road-to-2-million-websocket-connections).
+
+- Distributed clustering is not possible. 
+    - Heroku [firewalls dynos off from one another](https://devcenter.heroku.com/articles/dynos#networking). This means things like [distributed Phoenix channels](https://dockyard.com/blog/2016/01/28/running-elixir-and-phoenix-projects-on-a-cluster-of-nodes) and [distributed tasks](https://elixir-lang.org/getting-started/mix-otp/distributed-tasks-and-configuration.html) will need to rely on something like Redis instead of Elixir's built-in distribution.
+
+- In-memory state such as those in [Agents](https://elixir-lang.org/getting-started/mix-otp/agent.html), [GenServers](https://elixir-lang.org/getting-started/mix-otp/genserver.html), and [ETS](https://elixir-lang.org/getting-started/mix-otp/ets.html) will be lost every 24 hours. 
+    - Heroku [restarts dynos](https://devcenter.heroku.com/articles/dynos#restarting) every 24 hours regardless of whether the node is healthy.
+
+- [Remote shells](https://hexdocs.pm/iex/IEx.html#module-remote-shells) and remote observer are not possible. 
+    - Heroku does not allow SSH access to your dynos so you can not inspect, debug, or trace your production nodes using things like [the built-in Observer](https://elixir-lang.org/getting-started/mix-otp/supervisor-and-application.html#observer).
+
+- Hot upgrades are not possible. 
+    - Heroku deployments always replace dynos so websocket connections, running processes, etc will be lost on every deploy.
+
+If you're looking for a platform without these limitations, [Gigalixir](https://www.gigalixir.com/) is an Elixir-only PaaS, very similar to Heroku, designed to solve these problems.
+
 ## Steps
 
 Let's separate this process into a few steps so we can keep track of where we are.

--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -26,7 +26,7 @@ Heroku is a great platform and Elixir performs well on it. However, you may run 
 
 If you are just getting started or you don't expect to use the features above, Heroku should be enough for your needs. For instance, if you are migrating an existing application running on Heroku to Phoenix, keeping a similar set of features, Elixir will perform just as well or even better then your current stack.
  
-If you want a platform-as-a-service without these limitations, try [Gigalixir](http://gigalixir.readthedocs.io/). If you don't want a PaaS, try [Distillery](https://github.com/bitwalker/distillery).
+If you want a platform-as-a-service without these limitations, try [Gigalixir](http://gigalixir.readthedocs.io/). If you would rather deploy to a cloud platform, such as EC2, Google Cloud, etc, consider [Distillery](https://github.com/bitwalker/distillery).
 
 ## Steps
 


### PR DESCRIPTION
As discussed in issue #701, many beginners are surprised to find out later on that Heroku has some serious limitations for Elixir apps. This pull request adds a limitations section to the Heroku guide to help them avoid being bitten down the road.