### PR TITLE
Use Elixir comment hash sign instead of C-like //

### DIFF
--- a/docs/bonus_guides/seeding_data.md
+++ b/docs/bonus_guides/seeding_data.md
@@ -53,8 +53,8 @@ defmodule <%= application_name %>.DatabaseSeeder do
   alias <%= application_name %>.Repo
   alias <%= application_name %>.Link
 
-  @titles_list ["Erlang", "Elixir", "Phoenix Framework"] // list of titles
-  @urls_list ["http://www.erlang.org", "http://www.elixir-lang.org", "http://www.phoenixframework.org"] // list of urls
+  @titles_list ["Erlang", "Elixir", "Phoenix Framework"] # list of titles
+  @urls_list ["http://www.erlang.org", "http://www.elixir-lang.org", "http://www.phoenixframework.org"] # list of urls
 
   def insert_link do
     Repo.insert! %Link{


### PR DESCRIPTION
Fix syntax issue in a code example that was confusing the syntax highlighter of [the HTML page](https://hexdocs.pm/phoenix/1.3.0-rc.3/seeding_data.html#content).