### PR TITLE
Fix GenStage link in Running Asynchronous Tasks

### DIFF
--- a/docs/bonus_guides/task_supervisor.md
+++ b/docs/bonus_guides/task_supervisor.md
@@ -116,4 +116,4 @@ the error.
 
 It's worth noting that if these tasks fail, they won't be retried. Consider
 building a solution using
-[GenStage](https://hexdocs.pm/gen_stage/Experimental.GenStage.html)
+[GenStage](https://hexdocs.pm/gen_stage/GenStage.html)


### PR DESCRIPTION
The link to GenStage is broken since it's a reference to when GenStage was experimental