### PR TITLE
Application inference in Elixir 1.4

### DIFF
--- a/docs/bonus_guides/using_mysql.md
+++ b/docs/bonus_guides/using_mysql.md
@@ -44,8 +44,7 @@ defmodule Hello.Mixfile do
 . . .
 def application do
   [mod: {MysqlTester, []},
-  applications: [:phoenix, :cowboy, :logger,
-  :phoenix_ecto, :mariaex]]
+  extra_applications: [:logger, :runtime_tools]]
 end
 . . .
 ```


### PR DESCRIPTION
Since with Elixir 1.4, we no longer need to add the same dependency to dep list and applications list, updating `application` to comply with this rule. 
Reference: https://github.com/elixir-lang/elixir/blob/3002a061468c9bcf58e6e868690439fad339640b/lib/mix/lib/mix/tasks/compile.app.ex#L20
Do correct me if I'm wrong.  Each time I create a new Phoenix webapp I would get the following application
```
  def application do
    [
      mod: {GepDashboard.Application, []},
      extra_applications: [:logger, :runtime_tools]
    ]
  end
```
and its different from the documentation and where I do not see `extra_applications` and the same time deps are specified in two places.