### PR TITLE
format list of actions under Controllers overview

### DIFF
--- a/docs/introduction/overview.md
+++ b/docs/introduction/overview.md
@@ -25,7 +25,7 @@ Phoenix is made up of a number of distinct parts, each with its own purpose and 
     - Pipelines - allow easy application of groups of plugs to a set of routes
  - [Controllers](controllers.html)
     - provide functions, called *actions*, to handle requests
-    - Actions
+    - actions:
         - prepare data and pass it into views
         - invoke rendering via views
         - perform redirects


### PR DESCRIPTION
Made action lower case for format consistency, and added a colon to emphasize that bullet is functioning as a list heading.