### PR TITLE
Remove MIX_ENV=prod from mix phx.digest commands

### DIFF
--- a/docs/deployment/deployment.md
+++ b/docs/deployment/deployment.md
@@ -69,7 +69,7 @@ Compilation of static assets happens in two steps:
 
 ```console
 $ brunch build --production
-$ MIX_ENV=prod mix phoenix.digest
+$ mix phoenix.digest
 Check your digested files at "priv/static".
 ```
 
@@ -124,7 +124,7 @@ $ MIX_ENV=prod mix compile
 
 # Compile assets
 $ brunch build --production
-$ MIX_ENV=prod mix phoenix.digest
+$ mix phoenix.digest
 
 # Custom tasks (like DB migrations)
 $ MIX_ENV=prod mix ecto.migrate

--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -15,17 +15,17 @@ Heroku is a great platform and Elixir performs well on it. However, you may run 
 - Connections are limited.
     - Heroku [limits the number of simultaneous connections](https://devcenter.heroku.com/articles/http-routing#request-concurrency) as well as the [duration of each connection](https://devcenter.heroku.com/articles/limits#http-timeouts). It is common to use Elixir for real-time apps which need lots of concurrent, persistent connections, and Phoenix is capable of [handling over 2 million connections on a single server](http://www.phoenixframework.org/blog/the-road-to-2-million-websocket-connections).
 
-- Distributed clustering is not possible. 
+- Distributed clustering is not possible.
     - Heroku [firewalls dynos off from one another](https://devcenter.heroku.com/articles/dynos#networking). This means things like [distributed Phoenix channels](https://dockyard.com/blog/2016/01/28/running-elixir-and-phoenix-projects-on-a-cluster-of-nodes) and [distributed tasks](https://elixir-lang.org/getting-started/mix-otp/distributed-tasks-and-configuration.html) will need to rely on something like Redis instead of Elixir's built-in distribution.
 
-- In-memory state such as those in [Agents](https://elixir-lang.org/getting-started/mix-otp/agent.html), [GenServers](https://elixir-lang.org/getting-started/mix-otp/genserver.html), and [ETS](https://elixir-lang.org/getting-started/mix-otp/ets.html) will be lost every 24 hours. 
+- In-memory state such as those in [Agents](https://elixir-lang.org/getting-started/mix-otp/agent.html), [GenServers](https://elixir-lang.org/getting-started/mix-otp/genserver.html), and [ETS](https://elixir-lang.org/getting-started/mix-otp/ets.html) will be lost every 24 hours.
     - Heroku [restarts dynos](https://devcenter.heroku.com/articles/dynos#restarting) every 24 hours regardless of whether the node is healthy.
 
-- [Remote shells](https://hexdocs.pm/iex/IEx.html#module-remote-shells) and remote observer are not possible. 
+- [Remote shells](https://hexdocs.pm/iex/IEx.html#module-remote-shells) and remote observer are not possible.
     - Heroku does not allow SSH access to your dynos so you can not inspect, debug, or trace your production nodes using things like [the built-in Observer](https://elixir-lang.org/getting-started/mix-otp/supervisor-and-application.html#observer).
 
 If you are just getting started or you don't expect to use the features above, Heroku should be enough for your needs. For instance, if you are migrating an existing application running on Heroku to Phoenix, keeping a similar set of features, Elixir will perform just as well or even better then your current stack.
- 
+
 If you want a platform-as-a-service without these limitations, try [Gigalixir](http://gigalixir.readthedocs.io/). If you would rather deploy to a cloud platform, such as EC2, Google Cloud, etc, consider [Distillery](https://github.com/bitwalker/distillery).
 
 ## Steps
@@ -198,7 +198,6 @@ Lastly, we'll need to create a [Procfile](https://devcenter.heroku.com/articles/
 
 ```
 web: MIX_ENV=prod mix phx.server
-
 ```
 
 ## Creating Environment Variables in Heroku


### PR DESCRIPTION
`MIX_ENV` is not used by `mix phx.digest` in any way.