### PR TITLE
Add Plug.RequestId to the defaults Plugs at Endpoint plugs section on…

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -679,6 +679,8 @@ Endpoints organize all the plugs common to every request, and apply them before 
 
 - [Plug.Static](http://hexdocs.pm/plug/Plug.Static.html) - serves static assets. Since this plug comes before the logger, serving of static assets is not logged
 
+- [Plug.RequestId](http://hexdocs.pm/plug/Plug.RequestId.html) - generates a unique request id for each request. 
+
 - [Plug.Logger](http://hexdocs.pm/plug/Plug.Logger.html) - logs incoming requests
 
 - [Phoenix.CodeReloader](http://hexdocs.pm/phoenix/Phoenix.CodeReloader.html) - a plug that enables code reloading for all entries in the web directory. It is configured directly in the Phoenix application


### PR DESCRIPTION
On Phoenix 1.3.0 RequestId plug was added by default at hello_we/endpoint.ex.  The commit will add the info about it.