### PR TITLE
Update missing instructions to update the delete function on CMS cont…

### DIFF
--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -886,7 +886,9 @@ With our new plugs in place, we can now modify our `create`, `update`, and `dele
     end
   end
 
-  def delete(conn, _) do
+- def delete(conn, %{"id" => id}) do
++ def delete(conn, _) do
+-   page = CMS.get_page!(id)
 +   {:ok, _page} = CMS.delete_page(conn.assigns.page)
 
     conn


### PR DESCRIPTION
The original delete function had:
def delete(conn, %{"id" => id}) do
  page = CMS.get_page!(id)
And page nor id aren't used to as we are retrieving the page from the assigns.
This push only update the code, and prevent warnings on the debug.