### PR TITLE
remove extra space following end of sentences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ git rebase master
 
 #### Running the Guides Locally
 
-Generating guides requires two separate running processes.  One watches the files for changes, and will regenerate the files as they change.  The other serves the files so they can be viewed in a web browser.
+Generating guides requires two separate running processes. One watches the files for changes, and will regenerate the files as they change. The other serves the files so they can be viewed in a web browser.
 
 In the first terminal, run:
 

--- a/docs/phoenix_mix_tasks.ex
+++ b/docs/phoenix_mix_tasks.ex
@@ -246,7 +246,7 @@ Compiling 17 files (.ex)
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
 ```
 
-If we don't want to create a context or schema for our resource we can use the `--no-context` flag.  Note that this still requires a context module name as a parameter.
+If we don't want to create a context or schema for our resource we can use the `--no-context` flag. Note that this still requires a context module name as a parameter.
 
 ```console
 $ mix phx.gen.html Blog Post posts body:string word_count:integer --no-context

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -238,7 +238,7 @@ end
 
 ## Path Helpers
 
-Path helpers are functions which are dynamically defined on the `Router.Helpers` module for an individual application. For us, that is `HelloWeb.Router.Helpers`.  Their names are derived from the name of the controller used in the route definition. Our controller is `HelloWeb.PageController`, and `page_path` is the function which will return the path to the root of our application.
+Path helpers are functions which are dynamically defined on the `Router.Helpers` module for an individual application. For us, that is `HelloWeb.Router.Helpers`. Their names are derived from the name of the controller used in the route definition. Our controller is `HelloWeb.PageController`, and `page_path` is the function which will return the path to the root of our application.
 
 That's a mouthful. Let's see it in action. Run `$ iex -S mix` at the root of the project. When we call the `page_path` function on our router helpers with the `Endpoint` or connection and action as arguments, it returns the path to us.
 

--- a/docs/testing/testing_controllers.md
+++ b/docs/testing/testing_controllers.md
@@ -11,7 +11,7 @@ mix phoenix.gen.json Thing things some_attr:string another_attr:string
 
 Thing is the Model, things is the table name, and some_attr and another_attr are database columns on table things of type string. Don't run this command, we're going to explore test driving out a similar result to what a generator would give us.
 
-Let's create a `User` model. Since model creation is not in scope of this guide, we will use the generator.  If you aren't familiar, read [this section of the Mix guide](mix_tasks.html#phoenix-specific-mix-tasks).
+Let's create a `User` model. Since model creation is not in scope of this guide, we will use the generator. If you aren't familiar, read [this section of the Mix guide](mix_tasks.html#phoenix-specific-mix-tasks).
 
 ```bash
 $ mix phoenix.gen.model User users name:string email:string
@@ -106,7 +106,7 @@ defmodule HelloPhoenix.UserControllerTest do
     assert response == expected
   end
 ```
-Let's take a look at what's going on here. We build our users, and use the `get` function to make a `GET` request to our `UserController` index action, which is piped into `json_response/2` along with the expected HTTP status code.  This will return the JSON from the response body, when everything is wired up properly. We represent the JSON we want the controller action to return with the variable `expected`, and assert that the `response` and `expected` are the same.
+Let's take a look at what's going on here. We build our users, and use the `get` function to make a `GET` request to our `UserController` index action, which is piped into `json_response/2` along with the expected HTTP status code. This will return the JSON from the response body, when everything is wired up properly. We represent the JSON we want the controller action to return with the variable `expected`, and assert that the `response` and `expected` are the same.
 
 Our expected data is a JSON response with a top level key of `"data"` containing an array of users that have `"name"` and `"email"` properties.
 
@@ -254,7 +254,7 @@ When we run the test again, it passes.
 
 The last item we'll cover is the case where we don't find a user in `show/2`.
 
-Try this one on your own and see what you come up with.  One possible solution will be given below.
+Try this one on your own and see what you come up with. One possible solution will be given below.
 
 Walking through our TDD steps, we add a test that supplies a non existent user id to `user_path` which returns a 404 status and an error message:
 

--- a/docs/views.md
+++ b/docs/views.md
@@ -300,7 +300,7 @@ defmodule HelloWeb.PageController do
 end
 ```
 
-Here, we have our `show/2` and `index/2` actions returning static page data. Instead of passing in `"show.html"` to `render/3` as the template name, we pass `"show.json"`.  This way, we can have views that are responsible for rendering HTML as well as JSON by pattern matching on different file types.
+Here, we have our `show/2` and `index/2` actions returning static page data. Instead of passing in `"show.html"` to `render/3` as the template name, we pass `"show.json"`. This way, we can have views that are responsible for rendering HTML as well as JSON by pattern matching on different file types.
 
 ```elixir
 defmodule HelloWeb.PageView do


### PR DESCRIPTION
For consistency, sentences with two spaces following the end have had one of the spaces removed.  
This could also held off on until the changes for today have been made.

Should this be added to CONTRIBUTING.md though?