### PR TITLE
Use String.duplicate/2 instead.

### DIFF
--- a/docs/testing/testing_models.md
+++ b/docs/testing/testing_models.md
@@ -279,26 +279,14 @@ Randomized with seed 305958
 
 The other business requirement for the `:bio` field is that it be a maximum of one hundred and forty characters. Let's write a test for that using the `errors_on/2` function again.
 
-Before we actually write the test, how are we going to handle a string that long without making a mess? A new function in `HelloPhoenix.ModelCase` is perfect for this. We'll create a `long_string/1` function which will send us back a string of "a"'s as long as we tell it to be.
-
-```elixir
-defmodule HelloPhoenix.ModelCase do
-  ...
-
-  def long_string(length) do
-    Enum.reduce (1..length), "", fn _, acc ->  acc <> "a" end
-  end
-end
-```
-
-We can now use `long_string/1` when changing the value of the `:bio` key in our `attrs`.
+We'll use String.duplicate/2 to produce n-long "a" string.
 
 ```elixir
 defmodule HelloPhoenix.UserTest do
   ...
-
+  
   test "bio must be at most 140 characters long" do
-    attrs = %{@valid_attrs | bio: long_string(141)}
+    attrs = %{@valid_attrs | bio: String.duplicate("a", 141)}
     assert {:bio, "should be at most 140 character(s)"} in errors_on(%User{}, attrs)
   end
 end


### PR DESCRIPTION
An Elixir's String.duplicate/2 function can be used at no risk instead of creating our own function.